### PR TITLE
Add C-H & C-D to edit w.ibar.input

### DIFF
--- a/config/binds.lua
+++ b/config/binds.lua
@@ -238,6 +238,8 @@ add_binds({"command", "search"}, {
     key({"Shift"},   "Insert",  function (w) w:insert_cmd(luakit.get_selection()) end),
     key({"Control"}, "w",       function (w) w:del_word() end),
     key({"Control"}, "u",       function (w) w:del_line() end),
+    key({"Control"}, "h",       function (w) w:del_backward_char() end),
+    key({"Control"}, "d",       function (w) w:del_forward_char() end),
     key({"Control"}, "a",       function (w) w:beg_line() end),
     key({"Control"}, "e",       function (w) w:end_line() end),
     key({"Control"}, "f",       function (w) w:forward_char() end),

--- a/config/window.lua
+++ b/config/window.lua
@@ -315,6 +315,26 @@ window.methods = {
         end
     end,
 
+    del_backward_char = function (w)
+        local i = w.ibar.input
+        local text = i.text
+        local pos = i.position
+
+        if pos > 1 then
+            i.text = string.sub(text, 0, pos - 1) .. string.sub(text, pos + 1)
+            i.position = pos - 1
+        end
+    end,
+
+    del_forward_char = function (w)
+        local i = w.ibar.input
+        local text = i.text
+        local pos = i.position
+
+        i.text = string.sub(text, 0, pos) .. string.sub(text, pos + 2)
+        i.position = pos
+    end,
+
     beg_line = function (w)
         local i = w.ibar.input
         i.position = 1


### PR DESCRIPTION
Allow the use of C-H to delete the previous char (like in Bash,
equivalent of backspace), and C-D to delete next char (like in
Bash, equivalent of del key).
