### PR TITLE
Title fix

### DIFF
--- a/config/binds.lua
+++ b/config/binds.lua
@@ -165,8 +165,9 @@ add_binds("normal", {
                                     end),
 
     buf("^yt$",                     function (w)
-                                        luakit.set_selection(w.win.title)
-                                        w:notify("Yanked title: " .. w.win.title)
+                                        local title = w:get_current():get_property("title")
+                                        luakit.set_selection(title)
+                                        w:notify("Yanked title: " .. title)
                                     end),
 
     -- Commands


### PR DESCRIPTION
minor fix for the `yt` keybind
yanks the actual page title, not the window title, which is often times abbreviated
