### PR TITLE
added -U commandline option to prevent libunique usage

### DIFF
--- a/luah.c
+++ b/luah.c
@@ -344,7 +344,7 @@ luaH_dofunction_on_error(lua_State *L)
 }
 
 void
-luaH_init(void)
+luaH_init(gboolean unique)
 {
     lua_State *L;
 
@@ -371,7 +371,8 @@ luaH_init(void)
 
 #if WITH_UNIQUE
     /* Export unique lib */
-    unique_lib_setup(L);
+    if (unique)
+        unique_lib_setup(L);
 #endif
 
     /* Export widget */

--- a/luah.h
+++ b/luah.h
@@ -145,7 +145,7 @@ luaH_warn(lua_State *L, const gchar *fmt, ...) {
     fprintf(stderr, "\n");
 }
 
-void luaH_init();
+void luaH_init(gboolean);
 gboolean luaH_parserc(const gchar *, gboolean);
 gboolean luaH_hasitem(lua_State *, gconstpointer);
 gint luaH_mtnext(lua_State *, gint);


### PR DESCRIPTION
hey mason,

quick fix that adds a new command line option: `-U`
it prevents libunique from being loaded. I could use that when developing, since I usually already have a luakit instance running (playing music or whatever) and so I can't test the stuff I'm working on without modifying `config/rc.lua`.
