### PR TITLE
Userscripts install and menu

### DIFF
--- a/lib/userscripts.lua
+++ b/lib/userscripts.lua
@@ -1,5 +1,6 @@
 -------------------------------------------------------
 -- Userscript support for luakit                     --
+-- © 2011 Constantin Schomburg <me@xconstruct.net>   --
 -- © 2010 Fabian Streitel <karottenreibe@gmail.com>  --
 -- © 2010 Mason Larobina  <mason.larobina@gmail.com> --
 -------------------------------------------------------
@@ -17,7 +18,8 @@ local webview = webview
 local bind = require("lousy.bind")
 local util = require("lousy.util")
 local lfs = require("lfs")
-local add_cmds = add_cmds
+local add_binds, add_cmds = add_binds, add_cmds
+local new_mode, menu_binds = new_mode, menu_binds
 local capi = { luakit = luakit }
 
 --- Evaluates and manages userscripts.
@@ -182,7 +184,7 @@ local function parse_header(header, file)
         if key then
             val = util.string.strip(val or "")
             -- Populate header table
-            if key == "name" or key == "description" or key == "version" then
+            if key == "name" or key == "description" or key == "version" or key == "homepage" then
                 -- Only grab the first of its kind
                 if not ret[key] then ret[key] = val end
             elseif key == "include" or key == "exclude" then
@@ -237,7 +239,8 @@ local function invoke(view, on_start)
     end
 end
 
-local function save(file, js)
+-- Saves an userscript
+function save(file, js)
     if not os.exists(dir) then
         util.mkdir(dir)
     end
@@ -246,6 +249,13 @@ local function save(file, js)
     f:write(js)
     f:close()
     load_js(dir .. "/" .. file)
+end
+
+-- Deletes an userscript
+function del(file)
+    if not scripts[file] then return end
+    os.remove(file)
+    scripts[file] = nil
 end
 
 --- Hook on the webview's load-status signal to invoke the userscripts.
@@ -266,7 +276,7 @@ end
 local cmd = bind.cmd
 add_cmds({
     -- Saves the content of the open view as an userscript
-    cmd({"userscriptinstall", "usinstall"}, function (w, a)
+    cmd({"userscriptinstall", "usi[nstall]"}, function (w, a)
         local view = w:get_current()
         local file = string.match(view.uri, "/(%w+%.user%.js)$")
         if (not file) then return w:error("URL is not a *.user.js file") end
@@ -276,7 +286,76 @@ add_cmds({
         if not header then return w:error("Could not find userscript header") end
         save(file, js)
     end),
+
+    cmd({"userscripts", "uscripts"}, function (w) w:set_mode("uscriptlist") end),
 })
+
+-- Add mode to display all userscripts in menu
+new_mode("uscriptlist", {
+    enter = function (w)
+        local rows = {{ "Userscripts", "Description", title = true }}
+        for file, script in pairs(scripts) do
+            local active = script:match(w:get_current().uri) and "*" or " "
+            local title = (script.name or file) .. " " .. (script.version or "")
+            table.insert(rows, { " " .. active .. title, " " .. script.description, file = file })
+        end
+        w.menu:build(rows)
+        w:notify("Use j/k to move, d delete, o to visit website, t tabopen, w winopen. '*' signalizes active scripts.", false)
+    end,
+
+    leave = function (w)
+        w.menu:hide()
+    end,
+})
+
+local key = bind.key
+add_binds("uscriptlist", util.table.join({
+    -- Delete userscript
+    key({}, "d", function (w)
+        local row = w.menu:get()
+        if row and row.file then
+            del(row.file)
+            w.menu:del()
+        end
+    end),
+
+    -- Open userscript homepage
+    key({}, "o", function (w)
+        local row = w.menu:get()
+        if row and row.file then
+            local homepage = scripts[row.file] and scripts[row.file].homepage
+            if homepage then
+                w:navigate(homepage)
+            end
+        end
+    end),
+
+    -- Open userscript homepage in new tab
+    key({}, "t", function (w)
+        local row = w.menu:get()
+        if row and row.file then
+            local homepage = scripts[row.file] and scripts[row.file].homepage
+            if homepage then
+                w:new_tab(homepage, false)
+            end
+        end
+    end),
+
+    -- Open userscript homepage in new window
+    key({}, "w", function (w)
+        local row = w.menu:get()
+        if row and row.file then
+            local homepage = scripts[row.file] and scripts[row.file].homepage
+            if homepage then
+                window.new(homepage)
+            end
+        end
+    end),
+
+    -- Close menu
+    key({}, "q", function (w) w:set_mode() end),
+
+}, menu_binds))
 
 -- Initialize the userscripts
 load_all()


### PR DESCRIPTION
This makes it possible to install/remove/list userscripts inside of luakit. If you open a .user.js-file in the browser, you can issue a :userscriptinstall / :usi[nstall] to place it in your scripts-folder.
It also adds a menu of currently installed scripts where you can remove them or visit their website via :userscripts / :uscripts.

I'm not totally happy with my way of fetching the user.js-content of the active view, looks a bit like a hack to me (at least it seems to be working). I also thought about using the download-handler and intercepting download-location, but that would probably make it even more difficult. Maybe you know a better solution.

This also resolves a problem with userscripts not starting with "// ==Userscript==". For example, I noticed Youtube Enhancer wraps the whole script in a "// <![CDATA[" tag, so the header pattern wouldn't recognize it.
