### PR TITLE
Auto open specific downloads

### DIFF
--- a/lib/downloads.lua
+++ b/lib/downloads.lua
@@ -93,18 +93,16 @@ status_timer:add_signal("timeout", function ()
     local running = 0
     for _, d in ipairs(downloads) do
         if is_running(d) then running = running + 1 end
-    end
-    for _, d in ipairs(downloads) do
-        -- Update download indicator widget
-        for _, w in pairs(window.bywidget) do
-            w.sbar.r.downloads.text = running == 0 and "" or running.."↓"
-        end
         -- Get speed table
         if not speeds[d] then speeds[d] = {} end
         local s = speeds[d]
         -- Save download progress
         s.last_size = s.current_size or 0
         s.current_size = d.current_size
+    end
+    -- Update download indicator widget
+    for _, w in pairs(window.bywidget) do
+        w.sbar.r.downloads.text = running == 0 and "" or running.."↓"
     end
     -- Stop after downloads finish
     if #downloads == 0 or running == 0 then

--- a/lib/downloads.lua
+++ b/lib/downloads.lua
@@ -49,6 +49,9 @@ default_dir = capi.luakit.get_special_dir("DOWNLOAD") or (os.getenv("HOME") .. "
 -- Tracks speed data for downloads by weak table.
 local speeds = setmetatable({}, { __mode = "k" })
 
+-- Track auto opened files to prevent multiple signals
+local auto_opened = setmetatable({}, { __mode = "k" })
+
 -- Setup signals on downloads module.
 lousy.signal.setup(_M, true)
 
@@ -99,6 +102,14 @@ status_timer:add_signal("timeout", function ()
         -- Save download progress
         s.last_size = s.current_size or 0
         s.current_size = d.current_size
+        -- Auto open finished files
+        if d.status == "finished" and not opening[d] and not auto_opened[d] then
+            auto_opened[d] = true
+            local should_open = _M.emit_signal("auto-open-filter", d.destination, d.mime_type)
+            if should_open then
+                open(d)
+            end
+        end
     end
     -- Update download indicator widget
     for _, w in pairs(window.bywidget) do
@@ -182,6 +193,7 @@ function open(d, w)
         if not is_running(d) then t:stop() end
         if d.status == "finished" then
             opening[d] = false
+            auto_opened[d] = true
             if _M.emit_signal("open-file", d.destination, d.mime_type, w) ~= true then
                 if w then
                     w:error(string.format("Can't open: %q (%s)", d.destination, d.mime_type))


### PR DESCRIPTION
This adds a filter which opens specific downloads automatically. A signal `auto-open-filter` is called for each finished download and when it returns true, the download is opened via `open`.

Example usage:

``` lua
downloads.add_signal("auto-open-filter", function(destination, mime_type)
    return mime_type == "application/pdf"
end)
```

Currently the user has to define the applications for `open-file` manually, right? Maybe we could default to `xdg-open` in the configs, to serve as an example and fallback.
