### PR TITLE
Settable homepage

### DIFF
--- a/config/binds.lua
+++ b/config/binds.lua
@@ -14,7 +14,6 @@ local strip, split = lousy.util.string.strip, lousy.util.string.split
 local scroll_step = globals.scroll_step or 20
 local more, less = "+"..scroll_step.."px", "-"..scroll_step.."px"
 local zoom_step = globals.zoom_step or 0.1
-local homepage = globals.homepage or "http://luakit.org"
 
 function get_homepage ()
    return globals.homepage or "http://luakit.org"


### PR DESCRIPTION
At the moment, in order to do something pretty basic (set a homepage which will come up both for new window and new tabs) a user has to either copy globals.lua or binds.lua into a user config file. This is a common configuration and should be settable in rc.lua (or a userconf.lua). 

This simple change replaces the `homepage` variable in binds.lua with a `get_homepage` function. This allows the user to set `globals.homepage` in rc.lua or a userconf.lua and have it work properly properly, without having to worry about the load order. Since it's a function in binds.lua, it will get the correct set value even if it is set after binds.lua is imported.
