### PR TITLE
fixed bug that prohibited page changes away from bookmarks page

### DIFF
--- a/lib/bookmarks.lua
+++ b/lib/bookmarks.lua
@@ -165,7 +165,7 @@ function del(index, save_bookmarks)
     -- Refresh open bookmarks views
     for _, w in pairs(window.bywidget) do
         for _, v in ipairs(w.tabs:get_children()) do
-            if string.match(v.uri, "^luakit://bookmarks/?") then
+            if string.match(v.uri, "^luakit://bookmarks/?") and v.status == "finished" then
                 v:reload()
             end
         end


### PR DESCRIPTION
one-commit bugfix:

when navigating away from the bookmarks page and changing tabs to
another bookmarks page while the former has not yet fully loaded,
the navigation request was aborted and the bookmarks page reloaded.
