### PR TITLE
Print informational messages on stdout, not stderr

### DIFF
--- a/config/rc.lua
+++ b/config/rc.lua
@@ -22,7 +22,7 @@ require "lousy"
 
 -- Small util functions to print output (info prints only when luakit.verbose is true)
 function warn(...) io.stderr:write(string.format(...) .. "\n") end
-function info(...) if luakit.verbose then io.stderr:write(string.format(...) .. "\n") end end
+function info(...) if luakit.verbose then io.stdout:write(string.format(...) .. "\n") end end
 
 -- Load users global config
 -- ("$XDG_CONFIG_HOME/luakit/globals.lua" or "/etc/xdg/luakit/globals.lua")


### PR DESCRIPTION
I saw in the C code also some prints to stderr that should maybe go to stdout, but I didn't study the entire code base.  But this fixes at least the "user level" output.
