### PR TITLE
tick and overlay for splitted links

### DIFF
--- a/lib/follow/init.lua
+++ b/lib/follow/init.lua
@@ -157,7 +157,7 @@ window.follow = (function () {
         }
 
         function createTick(hint) {
-            var tick = createSpan(hint, follow.theme.horiz_offset, follow.theme.vert_offset - hint.rect.height/2);
+            var tick = createSpan(hint, follow.theme.horiz_offset, follow.theme.vert_offset - hint.rect0.height/2);
             tick.style.font = follow.theme.tick_font;
             tick.style.color = follow.theme.tick_fg;
             if (isFrame(hint.element)) {


### PR DESCRIPTION
getBoundingClientRect() for a link, which is splitted in two lines, returns rectangle with size of whole two lines.
See bugs.gentoo.org page — link «bot policy» for example. If there are two links on the line: first link at the beginning and second link at the end (splitted to the next line) than the tick of one link will cover the tick of another one.
It's better to use rectangle which is calculated with help of getClientRects()[0] instead of bounding rectangle. Tick will be in right place.
However, overlay will be in the first line only. I don't know, is it necessary to draw overlay of several rectangles which will exactly cover text of link? I think that more than one rectangle per link is useless.
