### PR TITLE
added missing package to pkg-config invocation

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -46,7 +46,7 @@ have lua >= 5.1 installed)
 endif
 
 # Packages required to build luakit
-PKGS := gtk+-2.0 gthread-2.0 webkit-1.0 sqlite3 $(LUA_PKG_NAME)
+PKGS := gtk+-2.0 gthread-2.0 webkit-1.0 javascriptcoregtk-1.0 sqlite3 $(LUA_PKG_NAME)
 
 # Build luakit with libunqiue bindings (for writing simple single-
 # instance applications using dbus).


### PR DESCRIPTION
WebKitGtk+ has split into two packages, see:
http://mail.gnome.org/archives/gnome-announce-list/2011-September/msg00121.html

fixes the linker issue discussed on the mailing list
