### PR TITLE
bindings in non english layout

### DIFF
--- a/config/keymap.lua
+++ b/config/keymap.lua
@@ -1,0 +1,19 @@
+
+local keymap = {}
+
+-- A table that contains mappings for key names.
+-- If a keyname is in this table then convertion by group will not be applied
+keymap.map = {
+        ISO_Left_Tab = "Tab",
+    }
+
+-- true if a keyval of pressed key should be converted to the keyval which corresponds to the default keyboard layout
+keymap.convert_groups = {
+    -- for example: setxkbmap "us,ru,dvorak" "grp:caps_toggle"
+    [0] = true,     -- ru: conversion is useful for non-latin layout
+    [2] = false,    -- dvorak: such conversion is unconfortable for dvorak
+}
+
+return keymap
+
+-- vim: et:sw=4:ts=8:sts=4:tw=80

--- a/config/window.lua
+++ b/config/window.lua
@@ -167,9 +167,9 @@ window.init_funcs = {
     end,
 
     key_press_match = function (w)
-        w.win:add_signal("key-press", function (_, mods, key)
+        w.win:add_signal("key-press", function (_, mods, key, group, tr_key)
             -- Match & exec a bind
-            local success, match = pcall(w.hit, w, mods, key)
+            local success, match = pcall(w.hit, w, mods, key, {}, group, tr_key )
             if not success then
                 w:error("In bind call: " .. match)
             elseif match then
@@ -254,13 +254,13 @@ window.init_funcs = {
 -- Helper functions which operate on the window widgets or structure.
 window.methods = {
     -- Wrapper around the bind plugin's hit method
-    hit = function (w, mods, key, opts)
+    hit = function (w, mods, key, opts, group, tr_key)
         local opts = lousy.util.table.join(opts or {}, {
             enable_buffer = w:is_mode("normal"),
             buffer = w.buffer,
         })
 
-        local caught, newbuf = lousy.bind.hit(w, w.binds, mods, key, opts)
+        local caught, newbuf = lousy.bind.hit(w, w.binds, mods, key, opts, group, tr_key)
         if w.win then -- Check binding didn't cause window to exit
             w.buffer = newbuf
             w:update_buf()

--- a/widgets/common.c
+++ b/widgets/common.c
@@ -29,18 +29,20 @@
 gboolean
 key_press_cb(GtkWidget* UNUSED(win), GdkEventKey *ev, widget_t *w)
 {
-    guint keyval = 0;
+    guint transformed_keyval = ev->keyval;
     gdk_keymap_translate_keyboard_state(
             gdk_keymap_get_default(),
             ev->hardware_keycode,
             ev->state,
-            0, /* group */
-            &keyval, NULL, NULL, NULL);
+            0, /* default group */
+            &transformed_keyval, NULL, NULL, NULL);
     lua_State *L = globalconf.L;
     luaH_object_push(L, w->ref);
     luaH_modifier_table_push(L, ev->state);
-    luaH_keystr_push(L, keyval);
-    gint ret = luaH_object_emit_signal(L, -3, "key-press", 2, 1);
+    luaH_keystr_push(L, ev->keyval);
+    lua_pushinteger(L, ev->group);
+    luaH_keystr_push(L, transformed_keyval);
+    gint ret = luaH_object_emit_signal(L, -5, "key-press", 4, 1);
     gboolean catch = ret && lua_toboolean(L, -1) ? TRUE : FALSE;
     lua_pop(L, ret + 1);
     return catch;


### PR DESCRIPTION
This will allow to use binds in non English (Latin, in general) keyboard layout like Cyrillic.
Now when I'm on Cyrillic layout I have to switch to English, use bingings and switch again. Otherwise I'll get for example «:щ» not «:o» in command line.
