### PR TITLE
Fix Web Inspector always toggling when inspecting new element

### DIFF
--- a/lib/webinspector.lua
+++ b/lib/webinspector.lua
@@ -42,7 +42,7 @@ webview.init_funcs.inspector_setup = function (view, w)
     view:add_signal("show-inspector", function ()
         switch_inspector(w, view)
         -- We start in paned view
-        view.inspector:eval_js("WebInspector._toggleAttach();", "(webinspector.lua)")
+        view.inspector:eval_js("WebInspector.attached = true;", "(webinspector.lua)")
     end)
 
     view:add_signal("close-inspector", function (_, iview)


### PR DESCRIPTION
When inspecting a new element (via context menu or via inspect button in Web
inspector toolbar at the bottom) when web inspector is shown, it was always
changing it's attached state, i.e. when attached it got detached and vice
versa.

If we want to start attached, we should say we want start attached, not toggle
the state.
