### PR TITLE
Add page num to history uri

### DIFF
--- a/lib/history_chrome.lua
+++ b/lib/history_chrome.lua
@@ -253,7 +253,7 @@ add_cmds({
             w:new_tab(string.format("luakit://history/?q=%s",
                 capi.luakit.uri_encode(arg)))
         else
-            w:new_tab("luakit://history")
+            w:new_tab("luakit://history/?p=1")
         end
     end),
 })


### PR DESCRIPTION
`:history` now opens `luakit://history/?p=1` explicitly.

This allows flipping through history pages with <C-a> and <C-x> without having to first click through to page 2.
