### PR TITLE
Don't mark install file as executable.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ install:
 	install -d $(DESTDIR)/usr/share/pixmaps
 	install extras/luakit.png $(DESTDIR)/usr/share/pixmaps/
 	install -d $(DESTDIR)/usr/share/applications
-	install extras/luakit.desktop $(DESTDIR)/usr/share/applications/
+	install -m0644 extras/luakit.desktop $(DESTDIR)/usr/share/applications/
 	install -d $(MANPREFIX)/man1/
 	install -m644 luakit.1 $(MANPREFIX)/man1/
 


### PR DESCRIPTION
Desktop files shouldn't be marked as executable files. 
