### PR TITLE
Add command descriptions.

### DIFF
--- a/config/binds.lua
+++ b/config/binds.lua
@@ -291,36 +291,60 @@ add_cmds({
 
  -- cmd({command, alias1, ...}, function (w, arg, opts) .. end, opts),
  -- cmd("co[mmand]",            function (w, arg, opts) .. end, opts),
-    cmd("c[lose]",              function (w) w:close_tab() end),
-    cmd("print",                function (w) w.view:eval_js("print();") end),
-    cmd("stop",                 function (w) w.view:stop() end),
-    cmd("reload",               function (w) w:reload() end),
-    cmd("restart",              function (w) w:restart() end),
-    cmd("write",                function (w) w:save_session() end),
-    cmd("noh[lsearch]",         function (w) w:clear_search() end),
+    cmd("c[lose]",              "close current tab",
+        function (w) w:close_tab() end),
+    cmd("print",                "print page",
+        function (w) w.view:eval_js("print();") end),
+    cmd("stop",                 "stop loading",
+        function (w) w.view:stop() end),
+    cmd("reload",               "reload page",
+        function (w) w:reload() end),
+    cmd("restart",              "restart browser (reload config files)",
+        function (w) w:restart() end),
+    cmd("write",                "save current session",
+        function (w) w:save_session() end),
+    cmd("noh[lsearch]",         "clear search highlighting",
+        function (w) w:clear_search() end),
 
-    cmd("back",                 function (w, a) w:back(tonumber(a) or 1) end),
-    cmd("f[orward]",            function (w, a) w:forward(tonumber(a) or 1) end),
-    cmd("inc[rease]",           function (w, a) w:navigate(w:inc_uri(tonumber(a) or 1)) end),
-    cmd("o[pen]",               function (w, a) w:navigate(w:search_open(a)) end),
-    cmd("t[abopen]",            function (w, a) w:new_tab(w:search_open(a)) end),
-    cmd("w[inopen]",            function (w, a) window.new{w:search_open(a)} end),
-    cmd({"javascript", "js"},   function (w, a) w.view:eval_js(a) end),
+    cmd("back",                 "go back",
+        function (w, a) w:back(tonumber(a) or 1) end),
+    cmd("f[orward]",            "go forward",
+        function (w, a) w:forward(tonumber(a) or 1) end),
+    cmd("inc[rease]",           "go to next page (increment number in URL)",
+        function (w, a) w:navigate(w:inc_uri(tonumber(a) or 1)) end),
+    cmd("o[pen]",               "open page",
+        function (w, a) w:navigate(w:search_open(a)) end),
+    cmd("t[abopen]",            "open page in new tab",
+        function (w, a) w:new_tab(w:search_open(a)) end),
+    cmd("w[inopen]",            "open page in new window",
+        function (w, a) window.new{w:search_open(a)} end),
+    cmd({"javascript",   "js"}, "evaluate javascript snippet",
+        function (w, a) w.view:eval_js(a) end),
 
     -- Tab manipulation commands
-    cmd("tab",                  function (w, a) w:new_tab() w:run_cmd(":" .. a) end),
-    cmd("tabd[o]",              function (w, a) w:each_tab(function (v) w:run_cmd(":" .. a) end) end),
-    cmd("tabdu[plicate]",       function (w)    w:new_tab(w.view.history) end),
-    cmd("tabfir[st]",           function (w)    w:goto_tab(1) end),
-    cmd("tabl[ast]",            function (w)    w:goto_tab(-1) end),
-    cmd("tabn[ext]",            function (w)    w:next_tab() end),
-    cmd("tabp[revious]",        function (w)    w:prev_tab() end),
+    cmd("tab",                  "run command in new tab",
+        function (w, a) w:new_tab() w:run_cmd(":" .. a) end),
+    cmd("tabd[o]",              "run command in each tab",
+        function (w, a) w:each_tab(function (v) w:run_cmd(":" .. a) end) end),
+    cmd("tabdu[plicate]",       "duplicate tab",
+        function (w)    w:new_tab(w.view.history) end),
+    cmd("tabfir[st]",           "go to first tab",
+        function (w)    w:goto_tab(1) end),
+    cmd("tabl[ast]",            "go to last tab",
+        function (w)    w:goto_tab(-1) end),
+    cmd("tabn[ext]",            "go to next tab",
+        function (w)    w:next_tab() end),
+    cmd("tabp[revious]",        "go to previous tab",
+        function (w)    w:prev_tab() end),
 
-    cmd("q[uit]",               function (w, a, o) w:close_win(o.bang) end),
-    cmd({"viewsource",  "vs" }, function (w, a, o) w:toggle_source(not o.bang and true or nil) end),
-    cmd({"writequit", "wq"},    function (w, a, o) w:save_session() w:close_win(o.bang) end),
+    cmd("q[uit]",               "close window",
+        function (w, a, o) w:close_win(o.bang) end),
+    cmd({"viewsource",  "vs" }, "toggle source view",
+        function (w, a, o) w:toggle_source(not o.bang and true or nil) end),
+    cmd({"writequit", "wq"},    "write and quit",
+        function (w, a, o) w:save_session() w:close_win(o.bang) end),
 
-    cmd("lua", function (w, a)
+    cmd("lua", "evaluate lua snippet", function (w, a)
         if a then
             local ret = assert(loadstring("return function(w) return "..a.." end"))()(w)
             if ret then print(ret) end
@@ -329,7 +353,7 @@ add_cmds({
         end
     end),
 
-    cmd("dump", function (w, a)
+    cmd("dump", "save current webpage", function (w, a)
         local fname = string.gsub(w.win.title, '[^%w%.%-]', '_')..'.html' -- sanitize filename
         local file = a or luakit.save_file("Save file", w.win, xdg.download_dir or '.', fname)
         if file then

--- a/lib/bookmarks.lua
+++ b/lib/bookmarks.lua
@@ -261,7 +261,7 @@ add_binds("normal", {
 -- Add commands.
 local cmd = lousy.bind.cmd
 add_cmds({
-    cmd({"bookmark", "bm"}, function (w, a)
+    cmd({"bookmark", "bm"}, "add bookmark", function (w, a)
         if not a then
             w:error("Missing bookmark arguments (use `:bookmark <uri> <tags>`)")
             return
@@ -271,11 +271,11 @@ add_cmds({
         add(uri, args)
     end),
 
-    cmd("bookdel", function (w, a)
+    cmd("bookdel", "delete bookmark", function (w, a)
         del(tonumber(a))
     end),
 
-    cmd("bookmarks", function (w)
+    cmd("bookmarks", "list bookmarks", function (w)
         w:navigate(chrome_page)
     end),
 })

--- a/lib/completion.lua
+++ b/lib/completion.lua
@@ -162,6 +162,10 @@ funcs = {
                         else
                             cmd = string.format(":%s (:%s)", cmd, b.cmds[1])
                         end
+
+                        local padd = string.rep(" ", 30 - #cmd)
+                        cmd = cmd .. padd .. b.desc
+
                         cmds[cmd] = { escape(cmd), left = ":" .. b.cmds[1] }
                         break
                     end

--- a/lib/downloads.lua
+++ b/lib/downloads.lua
@@ -258,33 +258,33 @@ add_binds("normal", {
 -- Download commands.
 local cmd = lousy.bind.cmd
 add_cmds({
-    cmd("down[load]", function (w, a)
+    cmd("down[load]", "download file", function (w, a)
         add(a)
     end),
 
     -- View all downloads in an interactive menu
-    cmd("downloads", function (w)
+    cmd("downloads", "list downloads", function (w)
         w:set_mode("downloadlist")
     end),
 
-    cmd("dd[elete]", function (w, a)
+    cmd("dd[elete]", "delete download", function (w, a)
         local d = downloads[assert(tonumber(a), "invalid index")]
         if d then delete(d) end
     end),
 
-    cmd("dc[ancel]", function (w, a)
+    cmd("dc[ancel]", "cancel download", function (w, a)
         local d = downloads[assert(tonumber(a), "invalid index")]
         if d then cancel(d) end
     end),
 
-    cmd("dr[estart]", function (w, a)
+    cmd("dr[estart]", "restart download", function (w, a)
         local d = downloads[assert(tonumber(a), "invalid index")]
         if d then restart(d) end
     end),
 
-    cmd("dcl[ear]", clear),
+    cmd("dcl[ear]", "clear downloads list", clear),
 
-    cmd("do[pen]", function (w, a)
+    cmd("do[pen]", "open downloaded file", function (w, a)
         local d = downloads[assert(tonumber(a), "invalid index")]
         if d then open(d, w) end
     end),

--- a/lib/history_chrome.lua
+++ b/lib/history_chrome.lua
@@ -248,7 +248,7 @@ end)
 
 local cmd = lousy.bind.cmd
 add_cmds({
-    cmd("history", function (w, arg)
+    cmd("history", "open history tab", function (w, arg)
         if arg then
             w:new_tab(string.format("luakit://history/?q=%s",
                 capi.luakit.uri_encode(arg)))

--- a/lib/lousy/bind.lua
+++ b/lib/lousy/bind.lua
@@ -5,6 +5,7 @@
 
 --- Grab environment we need
 local assert = assert
+local error = error -- ##TODO
 local ipairs = ipairs
 local pairs = pairs
 local setmetatable = setmetatable
@@ -103,10 +104,11 @@ end
 
 --- Create new command binding.
 -- @param cmds A table of command names to match or "co[mmand]" string to parse.
+-- @param desc A short command description.
 -- @param func The callback function.
 -- @param opts Optional binding and callback options/state/metadata.
 -- @return A command binding struct.
-function cmd(cmds, func, opts)
+function cmd(cmds, desc, func, opts)
     -- Parse "co[mmand]" or literal.
     if type(cmds) == "string" then
         if string.match(cmds, "^(%w+)%[(%w+)%]") then
@@ -117,13 +119,20 @@ function cmd(cmds, func, opts)
         end
     end
 
+    if type(desc) ~= 'string' then
+        error("invalid description type", 2)
+    end
+    -- ##TODO
+
     assert(type(cmds) == "table", "invalid commands table type")
+ -- assert(type(desc) == 'string', "invalid description type")
     assert(#cmds > 0, "empty commands table")
     assert(type(func) == "function", "invalid function type")
 
     return {
         type = "command",
         cmds = cmds,
+        desc = desc,
         func = func,
         opts = opts or {},
     }

--- a/lib/proxy.lua
+++ b/lib/proxy.lua
@@ -194,7 +194,7 @@ new_mode("proxymenu", {
 
 local cmd = lousy.bind.cmd
 add_cmds({
-    cmd("proxy",
+    cmd("proxy", "add proxy server",
         function (w, a)
             local params = lousy.util.string.split(a or '')
             if not a then

--- a/lib/quickmarks.lua
+++ b/lib/quickmarks.lua
@@ -152,7 +152,7 @@ add_binds("normal", {
 local cmd = lousy.bind.cmd
 add_cmds({
     -- Quickmark add (`:qmark f http://forum1.com, forum2.com, imdb some artist`)
-    cmd("qma[rk]", function (w, a)
+    cmd("qma[rk]", "add quickmark", function (w, a)
         local token, uris = string.match(lousy.util.string.strip(a), "^(%w)%s+(.+)$")
         assert(token, "invalid token")
         uris = lousy.util.string.split(uris, ",%s+")
@@ -161,7 +161,7 @@ add_cmds({
     end),
 
     -- Quickmark edit (`:qmarkedit f` -> `:qmark f furi1, furi2, ..`)
-    cmd({"qmarkedit", "qme"}, function (w, a)
+    cmd({"qmarkedit", "qme"}, "edit quickmark", function (w, a)
         token = lousy.util.string.strip(a)
         assert(#token == 1, "invalid token length: " .. token)
         local uris = get(token)
@@ -169,7 +169,7 @@ add_cmds({
     end),
 
     -- Quickmark del (`:delqmarks b-p Aa z 4-9`)
-    cmd("delqm[arks]", function (w, a)
+    cmd("delqm[arks]", "delete quickmark", function (w, a)
         -- Find and del all range specifiers
         string.gsub(a, "(%w%-%w)", function (range)
             range = "["..range.."]"
@@ -183,10 +183,10 @@ add_cmds({
     end),
 
     -- View all quickmarks in an interactive menu
-    cmd("qmarks", function (w) w:set_mode("qmarklist") end),
+    cmd("qmarks", "list all quickmarks", function (w) w:set_mode("qmarklist") end),
 
     -- Delete all quickmarks
-    cmd({"delqmarks!", "delqm!"}, function (w) delall() end),
+    cmd({"delqmarks!", "delqm!"}, "delete all quickmarks", function (w) delall() end),
 })
 
 -- Add mode to display all quickmarks in an interactive menu

--- a/lib/tabhistory.lua
+++ b/lib/tabhistory.lua
@@ -79,7 +79,7 @@ end
 -- Add `:history` command to view all history items for the current tab in an interactive menu.
 local cmd = lousy.bind.cmd
 add_cmds({
-    cmd("tabhistory", window.methods.tab_history),
+    cmd("tabhistory", "list history for tab", window.methods.tab_history),
 })
 
 -- vim: et:sw=4:ts=8:sts=4:tw=80

--- a/lib/undoclose.lua
+++ b/lib/undoclose.lua
@@ -112,7 +112,7 @@ add_binds("undolist", lousy.util.table.join({
 -- Add `:undolist` command to view all closed tabs in an interactive menu
 local cmd = lousy.bind.cmd
 add_cmds({
-    cmd("undolist", function (w, a)
+    cmd("undolist", "undo closed tabs by entry", function (w, a)
         if #(w.closed_tabs) == 0 then
             w:notify("No closed tabs to display")
         else

--- a/lib/userscripts.lua
+++ b/lib/userscripts.lua
@@ -275,7 +275,7 @@ end
 local cmd = bind.cmd
 add_cmds({
     -- Saves the content of the open view as an userscript
-    cmd({"userscriptinstall", "usi", "usinstall"}, function (w, a)
+    cmd({"userscriptinstall", "usi", "usinstall"}, "install userscript", function (w, a)
         local view = w.view
         local file = string.match(view.uri, "/([^/]+%.user%.js)$")
         if (not file) then return w:error("URL is not a *.user.js file") end
@@ -287,7 +287,8 @@ add_cmds({
         w:notify("Installed userscript to: " .. dir .. "/" .. file)
     end),
 
-    cmd({"userscripts", "uscripts"}, function (w) w:set_mode("uscriptlist") end),
+    cmd({"userscripts", "uscripts"}, "list userscripts",
+        function (w) w:set_mode("uscriptlist") end),
 })
 
 -- Add mode to display all userscripts in menu

--- a/lib/webinspector.lua
+++ b/lib/webinspector.lua
@@ -70,7 +70,7 @@ end
 
 local cmd = lousy.bind.cmd
 add_cmds({
-    cmd("in[spect]", function (w, _, o)
+    cmd("in[spect]", "open DOM inspector", function (w, _, o)
         local v = w.view
         if o.bang then -- "inspect!" toggles inspector
             (v.inspector and v.close_inspector or v.show_inspector)(v)


### PR DESCRIPTION
Adds short descriptions to commands, shown in the tab completion list similar to pentadactyl. Modifies the `lousy.bind.cmd` parameters, and changes uses of this function accordingly.
