### PR TITLE
removed unneeded argument causing error with mutli profiles

### DIFF
--- a/lib/formfiller.lua
+++ b/lib/formfiller.lua
@@ -507,9 +507,7 @@ add_binds("formfiller", lousy.util.table.join({
         local row = w.menu:get()
         local form = row.form
         w:set_mode()
-        for _, f in ipairs(w.view.frames) do
-            if apply_form(w, form) then return end
-        end
+        if apply_form(w, form) then return end
     end),
 }, menu_binds))
 


### PR DESCRIPTION
Hi,

I had problem when choosing one of formfiller profiles.
Error was because 'userdata' varaible had no 'form' field, or sth like that.
apply_form got 3 arguments and this function accepts only 2,
so I've just removed unneded one.

Br,
Pawel
