### PR TITLE
Optimize hint following

### DIFF
--- a/lib/follow/init.lua
+++ b/lib/follow/init.lua
@@ -264,13 +264,11 @@ window.follow = (function () {
             if (!follow.tickParent) {
                 var tickParent = createElement("div");
                 tickParent.id = "luakit_follow_tickParent";
-                document.body.appendChild(tickParent);
                 follow.tickParent = tickParent;
             }
             if (!follow.overlayParent) {
                 var overlayParent = createElement("div");
                 overlayParent.id = "luakit_follow_overlayParent";
-                document.body.appendChild(overlayParent);
                 follow.overlayParent = overlayParent;
             }
         },
@@ -308,6 +306,8 @@ window.follow = (function () {
                 hint.setId(ids[i]);
                 hint.show();
             }
+            document.body.appendChild(follow.overlayParent);
+            document.body.appendChild(follow.tickParent);
         },
 
         // Filters the hints according to the given string and ID.


### PR DESCRIPTION
Currently hint following is not at all fast in luakit. You can see it, for example, on http://ompldr.org/vZWxwdg (it's a 50x50 table with links). Doing a 'f'ollow takes a lot more time than in other browsers, like dwb or firefox with vimperator.
This pull request seems to speed it up a lot
