### PR TITLE
Allow for prefixes on follow hints.

### DIFF
--- a/config/rc.lua
+++ b/config/rc.lua
@@ -111,7 +111,10 @@ require "follow"
 
 -- Use a custom charater set for hint labels
 --local s = follow.label_styles
---follow.label_maker = s.sort(s.reverse(s.charset("asdfqwerzxcv")))
+-- Prefix all labels with ',' so we don't break matching against text directly.
+-- Now we aren't forced (but still able) to match only hint labels.
+--local myprefix = ','
+--follow.label_maker = s.sort(s.prefix(myprefix, s.reverse(s.charset("asdfqwerzxcv"))))
 
 -- Match only hint labels
 --follow.pattern_maker = follow.pattern_styles.match_label

--- a/lib/follow.lua
+++ b/lib/follow.lua
@@ -417,6 +417,19 @@ label_styles = {
             return labels
         end
     end,
+
+    -- Chainable style: prefixes labels
+    prefix = function (pre, make_labels)
+        return function (size)
+            local labels = make_labels(size)
+            local rawset, rawget, reverse = rawset, rawget, string.reverse
+            local labels = make_labels(size)
+            for i = 1, #labels do
+                rawset(labels, i, pre .. rawget(labels, i))
+            end
+            return labels
+        end
+    end,
 }
 
 -- Default follow style


### PR DESCRIPTION
Sometimes it's easier to follow a link by just typing out the link text, but
this is not possible when using letters as hint labels. To get around this, we
add a transformer to the charset function pipeline that allows for a prefix to
be placed on all labels. For example, 'faa' becomes ',faa'. Now we can very
easily match using either method with no conflicts.
