### PR TITLE
Fixed compiler warning regarding ncol.

### DIFF
--- a/clib/sqlite3.c
+++ b/clib/sqlite3.c
@@ -215,7 +215,7 @@ luaH_bind_value(lua_State *L, sqlite3_stmt *stmt, gint bidx, gint idx)
 static gint
 luaH_sqlite3_do_exec(lua_State *L, sqlite3_stmt *stmt)
 {
-    gint ret = sqlite3_step(stmt), rows = 0, ncol;
+    gint ret = sqlite3_step(stmt), rows = 0, ncol = 0;
 
     /* determine if this statement returns rows */
     if (ret == SQLITE_DONE || ret == SQLITE_ROW) {


### PR DESCRIPTION
Another trivial fix. :)

Original warning:

```
cc -c clib/sqlite3.c -o clib/sqlite3.o
clib/sqlite3.c: In function ‘luaH_sqlite3_do_exec’:
clib/sqlite3.c:237:9: warning: ‘ncol’ may be used uninitialized in this function [-Wmaybe-uninitialized]
```
