### PR TITLE
Fix input non-English word error

### DIFF
--- a/lib/lousy/bind.lua
+++ b/lib/lousy/bind.lua
@@ -279,7 +279,7 @@ end
 -- the buffer.
 -- @return The new buffer truncated to 10 characters (if you need more buffer
 -- then use the input bar for whatever you are doing).
-function hit(object, binds, mods, key, args)    
+function hit(object, binds, mods, key, args)
     -- Convert keys using map
     key = map[key] or key
 


### PR DESCRIPTION
When I input non-English word in luakit anywhere. It's show same error:

Error: /usr/share/luakit/lib/lousy/bind.lua:286: bad argument #1 to 'wlen' (string expected, got nil)
stack traceback:
    /usr/share/luakit/lib/lousy/bind.lua:286: in function 'hit'
    /home/eshizhan/.config/luakit/window.lua:266: in function </home/eshizhan/.config/luakit/window.lua:260>
    [C]: in function 'xpcall'
    /home/eshizhan/.config/luakit/window.lua:174: in function </home/eshizhan/.config/luakit/window.lua:172>    

I think that when input non-English word, the "key" maybe eq. "nil".
