### PR TITLE
Manpage: removed non-default binding.

### DIFF
--- a/luakit.1.in
+++ b/luakit.1.in
@@ -257,9 +257,6 @@ Add current URI to bookmarks.
 .BR gb ", " gB
 Open bookmarks manager. If uppercase, open in new tab.
 .TP
-.BR <Ctrl>D
-Prompt to download current URI.
-.TP
 .BR / ", " ?
 Search / reverse search for a string on current page.
 .TP


### PR DESCRIPTION
A small mistake: I forgot I had set this custom ^D binding, which has obviously nothing to do in the default bindings in the man page.
