### PR TITLE
Add support for webkit's run-file-chooser signal

### DIFF
--- a/clib/filechooser.c
+++ b/clib/filechooser.c
@@ -1,0 +1,192 @@
+/*
+ * clib/filechooser.c - WebKitFileChooserRequest lua wrapper
+ *
+ * Copyright © 2011 Fabian Streitel <karottenreibe@gmail.com>
+ * Copyright © 2011 Mason Larobina <mason.larobina@gmail.com>
+ * Copyright © 2013 binlain <lainex@gmx.de>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "common/luaobject.h"
+#include "clib/filechooser.h"
+#include "luah.h"
+#include "globalconf.h"
+#include "stdlib.h"
+
+#include <webkit/webkitfilechooserrequest.h>
+#include <glib/gstdio.h>
+
+/** Internal data structure for webkit's filechooser request. */
+typedef struct {
+    /** Common \ref lua_object_t header. \see LUA_OBJECT_HEADER */
+    LUA_OBJECT_HEADER
+    WebKitFileChooserRequest* webkit_request;
+    gboolean completed; //True if the request was either canceled or fulfilled
+    gpointer ref;
+} filechooser_t;
+
+static lua_class_t filechooser_class;
+LUA_OBJECT_FUNCS(filechooser_class, filechooser_t, filechooser)
+
+#define luaH_checkfilechooser(L, idx) luaH_checkudata(L, idx, &(filechooser_class))
+
+static gint
+luaH_filechooser_gc(lua_State *L)
+{
+    filechooser_t *filechooser = luaH_checkfilechooser(L, 1);
+    g_object_unref(G_OBJECT(filechooser->webkit_request));
+    return luaH_object_gc(L);
+}
+
+static void
+luaH_filechooser_checked_cancel(filechooser_t *filechooser)
+{
+    if(!filechooser->completed){ 
+        //webkit_file_chooser_request_cancel (filechooser->webkit_request);
+        filechooser->completed = TRUE;
+    }
+}
+
+static gint
+luaH_filechooser_cancel(lua_State *L)
+{
+    filechooser_t *filechooser = luaH_checkfilechooser(L, 1);
+    luaH_filechooser_checked_cancel(filechooser);
+    return 0;
+}
+
+static gint
+luaH_filechooser_select_files(lua_State *L)
+{
+    const gchar **files;
+    filechooser_t *filechooser = luaH_checkfilechooser(L, 1);
+    WebKitFileChooserRequest *request = filechooser->webkit_request;
+    if(!filechooser->completed){
+        if(lua_isstring(L, 2)){
+            //User responded with a string, meaning a single file was selected 
+            files = malloc(2);
+            files[0] = lua_tostring(L, 2);
+            files[1] = NULL;
+            webkit_file_chooser_request_select_files(request, files);
+            free(files);
+            filechooser->completed = TRUE;
+            return 0;
+        }
+
+        if(lua_istable(L, 2)){
+            //User responded with a table, meaning multiple files have been
+            //selected
+            gint len = lua_objlen(L, 2); //Length of the table
+            files = malloc(len+1);
+            //Iterate the table
+            for (gint n = 0; n < len; ++n) {
+                lua_rawgeti(L, 2, n);
+                files[n] = lua_tostring(L, -1); /*Returns null if the value isn't a 
+                                                  string (or number), so it's safe to use here, 
+                                                  because a wrong value would just terminate the 
+                                                  array earlier */
+                lua_pop(L, 1);
+            } 
+            files[len] = NULL;
+            webkit_file_chooser_request_select_files(request, files);
+            free(files);
+            filechooser->completed = TRUE;
+            return 0;
+        }
+        warn("Unsupported argument supplied to select_files");
+    }else{
+        warn("File chooser request is already completed!");
+    }
+    return 0;
+}
+
+static gint
+luaH_filechooser_get_mime_types(lua_State *L, filechooser_t *filechooser)
+{
+    const gchar * const *mimes = webkit_file_chooser_request_get_mime_types(filechooser->webkit_request);
+    luaH_push_char_array(L, mimes);
+    return 1;
+}
+
+static gint
+luaH_filechooser_get_selected_files(lua_State *L, filechooser_t *filechooser)
+{
+    const gchar * const *files = webkit_file_chooser_request_get_selected_files(filechooser->webkit_request);
+    luaH_push_char_array(L, files);
+    return 1;
+}
+
+static gint
+luaH_filechooser_get_multiple(lua_State *L, filechooser_t *filechooser)
+{
+    gboolean multiple = webkit_file_chooser_request_get_select_multiple(filechooser->webkit_request); lua_pushboolean(L, multiple);
+    return 1;
+}
+
+
+gint
+luaH_filechooser_push(lua_State *L, WebKitFileChooserRequest *f)
+{
+    filechooser_class.allocator(L);
+    filechooser_t *filechooser = luaH_checkfilechooser(L, -1);
+    filechooser->webkit_request = f;
+    filechooser->completed = FALSE;
+    g_object_ref(G_OBJECT(f));
+    return 1;
+}
+
+void filechooser_class_setup(lua_State *L)
+{
+    static const struct luaL_reg filechooser_methods[] =
+    {
+        LUA_CLASS_METHODS(filechooser)
+        { NULL, NULL }
+    };
+
+    static const struct luaL_reg filechooser_meta[] =
+    {
+        LUA_OBJECT_META(filechooser)
+        LUA_CLASS_META
+        { "cancel", luaH_filechooser_cancel },
+        { "select_files", luaH_filechooser_select_files },
+        { "__gc", luaH_filechooser_gc },
+        { NULL, NULL },
+    };
+
+    luaH_class_setup(L, &filechooser_class, "filechooser_request",
+             (lua_class_allocator_t) filechooser_new,
+             NULL, NULL,
+             filechooser_methods, filechooser_meta);
+
+    luaH_class_add_property(&filechooser_class, L_TK_MIME_TYPES,
+            NULL,
+            (lua_class_propfunc_t) luaH_filechooser_get_mime_types,
+            NULL);
+
+    luaH_class_add_property(&filechooser_class, L_TK_SELECTED_FILES,
+            NULL,
+            (lua_class_propfunc_t) luaH_filechooser_get_selected_files,
+            NULL);
+    
+    luaH_class_add_property(&filechooser_class, L_TK_MULTIPLE,
+            NULL,
+            (lua_class_propfunc_t) luaH_filechooser_get_multiple,
+            NULL);
+
+}
+
+// vim: ft=c:et:sw=4:ts=8:sts=4:tw=80

--- a/clib/filechooser.c
+++ b/clib/filechooser.c
@@ -113,7 +113,7 @@ luaH_filechooser_select_files(lua_State *L)
     }
     
     if(!filechooser->multiple_files){
-        luaL_error(L, "File chooser request does not accept multiple files");
+        luaL_error(L, "File chooser request does not accept multiple files, use select_file(string) instead");
         return 0;
     }
 
@@ -122,7 +122,7 @@ luaH_filechooser_select_files(lua_State *L)
 
     //Iterate the table
     for (gint n = 0; n < len; ++n) {
-        lua_rawgeti(L, 2, n);
+        lua_rawgeti(L, 2, n+1);
         files[n] = lua_tostring(L, -1); 
         lua_pop(L, 1);
     } 

--- a/clib/filechooser.c
+++ b/clib/filechooser.c
@@ -55,15 +55,6 @@ luaH_filechooser_gc(lua_State *L)
     return luaH_object_gc(L);
 }
 
-static void
-luaH_filechooser_checked_cancel(filechooser_t *filechooser)
-{
-    if(!filechooser->completed){ 
-        //webkit_file_chooser_request_cancel (filechooser->webkit_request);
-        filechooser->completed = TRUE;
-    }
-}
-
 static gint
 luaH_filechooser_select_file(lua_State *L)
 {

--- a/clib/filechooser.c
+++ b/clib/filechooser.c
@@ -41,10 +41,10 @@ luaH_filechooser_gc(lua_State *L)
     filechooser_t *filechooser = luaH_checkfilechooser(L, 1);
     WebKitFileChooserRequest *request = filechooser->webkit_request;
 
-	if(filechooser->handled){
-		//If we handled this request we referenced it earlier
-    	g_object_unref(G_OBJECT(request));
-	}
+    if(filechooser->handled){
+        //If we handled this request we referenced it earlier
+        g_object_unref(G_OBJECT(request));
+    }
 
     return luaH_object_gc(L);
 }
@@ -61,7 +61,7 @@ luaH_filechooser_select_files(lua_State *L)
         return 0;
     }
     
-	if(!filechooser->handled){
+    if(!filechooser->handled){
         luaL_error(L, "File chooser request isn't handled by lua");
         return 0;
     }
@@ -98,7 +98,7 @@ luaH_filechooser_select_files(lua_State *L)
 static gint
 luaH_filechooser_get_mime_types(lua_State *L, filechooser_t *filechooser)
 {
-	if(!filechooser->handled){
+    if(!filechooser->handled){
         luaL_error(L, "File chooser request isn't handled by lua");
         return 0;
     }
@@ -109,7 +109,7 @@ luaH_filechooser_get_mime_types(lua_State *L, filechooser_t *filechooser)
 static gint
 luaH_filechooser_get_selected_files(lua_State *L, filechooser_t *filechooser)
 {
-	if(!filechooser->handled){
+    if(!filechooser->handled){
         luaL_error(L, "File chooser request isn't handled by lua");
         return 0;
     }
@@ -120,7 +120,7 @@ luaH_filechooser_get_selected_files(lua_State *L, filechooser_t *filechooser)
 static gint
 luaH_filechooser_get_multiple(lua_State *L, filechooser_t *filechooser)
 {
-	if(!filechooser->handled){
+    if(!filechooser->handled){
         luaL_error(L, "File chooser request isn't handled by lua");
         return 0;
     }

--- a/clib/filechooser.h
+++ b/clib/filechooser.h
@@ -34,7 +34,7 @@ typedef struct {
     WebKitFileChooserRequest* webkit_request;
     gboolean completed, //True if the request was either canceled or fulfilled
              multiple_files,
-			 handled; //Indicated whether the request is handled by lua code or not
+             handled; //Indicated whether the request is handled by lua code or not
     const gchar * const * mime_types;
     const gchar * const * selected_files;
     gpointer ref;

--- a/clib/filechooser.h
+++ b/clib/filechooser.h
@@ -27,8 +27,21 @@
 #include <lua.h>
 #include <webkit/webkitfilechooserrequest.h>
 
+/** Internal data structure for webkit's filechooser request. */
+typedef struct {
+    /** Common \ref lua_object_t header. \see LUA_OBJECT_HEADER */
+    LUA_OBJECT_HEADER
+    WebKitFileChooserRequest* webkit_request;
+    gboolean completed, //True if the request was either canceled or fulfilled
+             multiple_files,
+			 handled; //Indicated whether the request is handled by lua code or not
+    const gchar * const * mime_types;
+    const gchar * const * selected_files;
+    gpointer ref;
+} filechooser_t;
+
 void filechooser_class_setup(lua_State*);
-gint luaH_filechooser_push(lua_State*, WebKitFileChooserRequest*);
+filechooser_t * luaH_filechooser_push(lua_State*, WebKitFileChooserRequest*);
 
 #endif
 

--- a/clib/filechooser.h
+++ b/clib/filechooser.h
@@ -1,0 +1,35 @@
+/*
+ * clib/filechooser.h - WebKitFileChooserRequest lua wrapper
+ *
+ * Copyright © 2011 Fabian Streitel <karottenreibe@gmail.com>
+ * Copyright © 2011 Mason Larobina <mason.larobina@gmail.com>
+ * Copyright © 2013 binlain <lainex@gmx.de>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef LUAKIT_CLIB_FILECHOOSER_H
+#define LUAKIT_CLIB_FILECHOOSER_H
+
+#include <lua.h>
+#include <webkit/webkitfilechooserrequest.h>
+
+void filechooser_class_setup(lua_State*);
+gint luaH_filechooser_push(lua_State*, WebKitFileChooserRequest*);
+
+#endif
+
+// vim: ft=c:et:sw=4:ts=8:sts=4:tw=80

--- a/common/lualib.h
+++ b/common/lualib.h
@@ -37,6 +37,25 @@ lua_CFunction lualib_dofunction_on_error;
             luaL_typerror(L, n, "function"); \
     } while(0)
 
+
+/** Push a NULL terminated array of strings on the stack (as lua table) or nil,
+ * if the array is NULL
+ * \param L The Lua stack.
+ * \param array The NULL terminated array of C-style strings
+ */
+static inline void luaH_push_char_array(lua_State *L, const gchar * const * array){
+    if(array){
+        lua_newtable(L); 
+        for(gint n = 0; array[n] != NULL; ++n){
+            lua_pushnumber(L, n);
+            lua_pushstring(L, array[n]);
+            lua_rawset(L, -3);
+        }
+    }else{
+        lua_pushnil(L);
+    }
+}
+
 /** Dump the Lua stack. Useful for debugging.
  * \param L The Lua VM state.
  */

--- a/common/lualib.h
+++ b/common/lualib.h
@@ -47,7 +47,7 @@ static inline void luaH_push_char_array(lua_State *L, const gchar * const * arra
     if(array){
         lua_newtable(L); 
         for(gint n = 0; array[n] != NULL; ++n){
-            lua_pushnumber(L, n);
+            lua_pushnumber(L, n+1);
             lua_pushstring(L, array[n]);
             lua_rawset(L, -3);
         }

--- a/common/tokenize.list
+++ b/common/tokenize.list
@@ -206,3 +206,6 @@ ymax
 ypage_size
 zoom_level
 zoom_step
+mime_types
+selected_files
+multiple

--- a/config/webview.lua
+++ b/config/webview.lua
@@ -232,18 +232,13 @@ webview.init_funcs = {
     end,
 
     run_file_chooser = function (view, w)
-        -- Action to take when a file choose is requested
-        -- Returns:
-        --  - false or nil to use webkit's built-in file chooser
-        --  - true to not use the built-in file chooser
-        -- A file chooser should be closed when the user navigates
+        -- Action to take when a file chooser is requested
         view:add_signal("run-file-chooser", function(v, request)
             -- print(request.multiple)
             -- print(request.selected_files)
             -- print(request.mime_types)
-            -- request:select_files({"path_to_file1", "path_to_file2"});
-            -- request:select_file("path_to_file");
-            return true
+            -- request:select_files({"/path/to/file"})
+            return false -- true if you want to handle this request
         end)
     end,
 }

--- a/config/webview.lua
+++ b/config/webview.lua
@@ -238,8 +238,12 @@ webview.init_funcs = {
         --  - true to not use the built-in file chooser
         -- A file chooser should be closed when the user navigates
         view:add_signal("run-file-chooser", function(v, request)
-            request:select_files({"/home/lain/.bashrc","/home/lain/.bash_profile"});
-            return true
+            -- print(request.multiple)
+            -- print(request.selected_files)
+            -- print(request.mime_types)
+            -- request:select_files({"path_to_file1", "path_to_file2"});
+            -- request:select_files("path_to_file");
+            return false
         end)
     end,
 }

--- a/config/webview.lua
+++ b/config/webview.lua
@@ -230,6 +230,22 @@ webview.init_funcs = {
             -- Return false to cancel the request.
         end)
     end,
+
+    -- File Chooser
+    -- May return one of the following:
+    --  - false or nil to use webkit's built-in file chooser
+    --  - true to not do anything
+    --  - a string containing the selected file
+    --  - a table containing multiple selected files
+    run_file_chooser = function (view, w)
+        -- multiple, boolean, if true, more than one file can be selected
+        -- mimes, table containing the accepted mime-types or nil, if all mimes
+        -- are accepted
+        -- selected_files, table containing initially selected files
+        view:add_signal("run-file-chooser", function(v, multiple, mimes, selected_files)
+            return false
+        end)
+    end,
 }
 
 -- These methods are present when you index a window instance and no window

--- a/config/webview.lua
+++ b/config/webview.lua
@@ -231,19 +231,15 @@ webview.init_funcs = {
         end)
     end,
 
-    -- File Chooser
-    -- May return one of the following:
-    --  - false or nil to use webkit's built-in file chooser
-    --  - true to not do anything
-    --  - a string containing the selected file
-    --  - a table containing multiple selected files
     run_file_chooser = function (view, w)
-        -- multiple, boolean, if true, more than one file can be selected
-        -- mimes, table containing the accepted mime-types or nil, if all mimes
-        -- are accepted
-        -- selected_files, table containing initially selected files
-        view:add_signal("run-file-chooser", function(v, multiple, mimes, selected_files)
-            return false
+        -- Action to take when a file choose is requested
+        -- Returns:
+        --  - false or nil to use webkit's built-in file chooser
+        --  - true to not use the built-in file chooser
+        -- A file chooser should be closed when the user navigates
+        view:add_signal("run-file-chooser", function(v, request)
+            request:select_files({"/home/lain/.bashrc","/home/lain/.bash_profile"});
+            return true
         end)
     end,
 }

--- a/config/webview.lua
+++ b/config/webview.lua
@@ -242,8 +242,8 @@ webview.init_funcs = {
             -- print(request.selected_files)
             -- print(request.mime_types)
             -- request:select_files({"path_to_file1", "path_to_file2"});
-            -- request:select_files("path_to_file");
-            return false
+            -- request:select_file("path_to_file");
+            return true
         end)
     end,
 }

--- a/luah.c
+++ b/luah.c
@@ -23,6 +23,7 @@
 
 /* include clib headers */
 #include "clib/download.h"
+#include "clib/filechooser.h"
 #include "clib/luakit.h"
 #include "clib/soup/soup.h"
 #include "clib/sqlite3.h"
@@ -326,6 +327,9 @@ luaH_init(void)
 
     /* Export download */
     download_class_setup(L);
+
+    /* Export file chooser */
+    filechooser_class_setup(L);
 
     /* Export sqlite3 */
     sqlite3_class_setup(L);

--- a/widgets/webview.c
+++ b/widgets/webview.c
@@ -289,6 +289,71 @@ new_window_decision_cb(WebKitWebView* UNUSED(v), WebKitWebFrame* UNUSED(f),
     return FALSE;
 }
 
+// See webview.lua -> run_file_chooser
+static gboolean run_file_chooser_cb(WebKitWebView *UNUSED(v), WebKitFileChooserRequest *request, widget_t *w){
+    lua_State *L = globalconf.L;
+    gboolean multiple, show_dialog = true; //Show webkit's internal file chooser dialog
+    const gchar **files;
+    const gchar * const *mimes;
+    const gchar * const *selected;
+
+    luaH_object_push(L, w->ref);
+
+    //Whether we accept multiple files
+    multiple = webkit_file_chooser_request_get_select_multiple(request);
+    lua_pushboolean(L, multiple);
+
+    //Push the accepted mime types on the stack
+    mimes = webkit_file_chooser_request_get_mime_types(request);
+    luaH_push_char_array(L, mimes); 
+    
+    //Push the selected files on the stack
+    selected = webkit_file_chooser_request_get_selected_files(request);
+    luaH_push_char_array(L, selected); 
+
+    gint ret = luaH_object_emit_signal(L, -4, "run-file-chooser", 3, 1);
+    
+    if(ret){
+        if(lua_isstring(L, -1)){
+            //User responded with a string, meaning a single file was selected 
+            show_dialog = false;
+            files = malloc(2);
+            files[0] = lua_tostring(L, -1);
+            files[1] = NULL;
+            webkit_file_chooser_request_select_files(request, files);
+            free(files);
+        }
+
+        if(lua_istable(L, -1)){
+            //User responded with a table, meaning multiple files have been
+            //selected
+            show_dialog = false;
+            gint len = lua_objlen(L, -1); //Length of the table
+            files = malloc(len+1);
+            //Iterate the table
+            for (gint n = 0; n < len; ++n) {
+                lua_rawgeti(L, -1, n);
+                files[n] = lua_tostring(L, -1); /*Returns null if the value isn't a 
+                                                  string (or number), so it's safe to use here, 
+                                                  because a wrong value would just terminate the 
+                                                  array earlier */
+                lua_pop(L, 1);
+            } 
+            files[len] = NULL;
+            webkit_file_chooser_request_select_files(request, files);
+            free(files);
+        }
+
+        if(lua_isboolean(L, -1) && lua_toboolean(L, -1)){
+            //User responded with true, don't show any dialog
+            show_dialog = false;
+        }
+    }
+
+    lua_pop(L, ret + 1);
+    return !show_dialog;
+}
+
 static WebKitWebView*
 create_web_view_cb(WebKitWebView* UNUSED(v), WebKitWebFrame* UNUSED(f),
         widget_t *w)
@@ -883,6 +948,7 @@ widget_webview(widget_t *w, luakit_token_t UNUSED(token))
       "signal::resource-request-starting",            G_CALLBACK(resource_request_starting_cb), w,
       "signal::scroll-event",                         G_CALLBACK(scroll_event_cb),              w,
       "signal::size-request",                         G_CALLBACK(size_request_cb),              w,
+      "signal::run-file-chooser",                     G_CALLBACK(run_file_chooser_cb),          w,
       NULL);
 
     g_object_connect(G_OBJECT(d->win),

--- a/widgets/webview/filechooser.c
+++ b/widgets/webview/filechooser.c
@@ -1,0 +1,36 @@
+/*
+ * widgets/webview/downloads.c - webkit webview download functions
+ *
+ * Copyright © 2010-2011 Mason Larobina <mason.larobina@gmail.com>
+ * Copyright © 2013 binlain <lainex@gmx.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "clib/filechooser.h"
+
+static gboolean
+run_file_chooser_request_cb(WebKitWebView* UNUSED(v), WebKitFileChooserRequest *request, widget_t *w)
+{
+    lua_State *L = globalconf.L;
+    luaH_object_push(L, w->ref);
+    luaH_filechooser_push(L, request);
+    gint ret = luaH_object_emit_signal(L, 1, "run-file-chooser", 1, 1);
+    gboolean handled = (ret && lua_toboolean(L, 2));
+    lua_pop(L, 1 + ret);
+    return handled;
+}
+
+// vim: ft=c:et:sw=4:ts=8:sts=4:tw=80

--- a/widgets/webview/filechooser.c
+++ b/widgets/webview/filechooser.c
@@ -20,15 +20,37 @@
  */
 
 #include "clib/filechooser.h"
+#include <webkit/webkitfilechooserrequest.h>
 
 static gboolean
 run_file_chooser_request_cb(WebKitWebView* UNUSED(v), WebKitFileChooserRequest *request, widget_t *w)
 {
     lua_State *L = globalconf.L;
     luaH_object_push(L, w->ref);
-    luaH_filechooser_push(L, request);
+    filechooser_t *request_object = luaH_filechooser_push(L, request);
+	//Set this to true for now so stuff running synchronous doesn't run into
+	//any problems
+	request_object->handled = TRUE;	
     gint ret = luaH_object_emit_signal(L, 1, "run-file-chooser", 1, 1);
     gboolean handled = (ret && lua_toboolean(L, 2));
+	if(request_object->completed){
+		//If this request was already fulfilled synchronouly we don't need to
+		//bother with the rest	
+		request_object->handled = FALSE; //false so the request object does not get unreferenced when the lua garbage collector kicks in
+    	lua_pop(L, 1 + ret);
+		if(!handled){
+			//The lua code selected files but didn't return true to handle the
+			//request, this is discouraged so throw an error
+			luaL_error(L, "select_files was called but the request wasn't explicitely handled (i.e. run_file_chooser didn't return true)");
+		}
+		return TRUE;
+	}
+	request_object->handled = handled;	
+	if(handled){
+		//If we are handling this request with lua code, we are doing so
+		//asyncronically, which means we need to reference it now
+    	g_object_ref(G_OBJECT(request));
+	}
     lua_pop(L, 1 + ret);
     return handled;
 }

--- a/widgets/webview/filechooser.c
+++ b/widgets/webview/filechooser.c
@@ -1,5 +1,5 @@
 /*
- * widgets/webview/downloads.c - webkit webview download functions
+ * widgets/webview/downloads.c - webkit file chooser request functions
  *
  * Copyright © 2010-2011 Mason Larobina <mason.larobina@gmail.com>
  * Copyright © 2013 binlain <lainex@gmx.de>

--- a/widgets/webview/filechooser.c
+++ b/widgets/webview/filechooser.c
@@ -28,29 +28,29 @@ run_file_chooser_request_cb(WebKitWebView* UNUSED(v), WebKitFileChooserRequest *
     lua_State *L = globalconf.L;
     luaH_object_push(L, w->ref);
     filechooser_t *request_object = luaH_filechooser_push(L, request);
-	//Set this to true for now so stuff running synchronous doesn't run into
-	//any problems
-	request_object->handled = TRUE;	
+    //Set this to true for now so stuff running synchronous doesn't run into
+    //any problems
+    request_object->handled = TRUE; 
     gint ret = luaH_object_emit_signal(L, 1, "run-file-chooser", 1, 1);
     gboolean handled = (ret && lua_toboolean(L, 2));
-	if(request_object->completed){
-		//If this request was already fulfilled synchronouly we don't need to
-		//bother with the rest	
-		request_object->handled = FALSE; //false so the request object does not get unreferenced when the lua garbage collector kicks in
-    	lua_pop(L, 1 + ret);
-		if(!handled){
-			//The lua code selected files but didn't return true to handle the
-			//request, this is discouraged so throw an error
-			luaL_error(L, "select_files was called but the request wasn't explicitely handled (i.e. run_file_chooser didn't return true)");
-		}
-		return TRUE;
-	}
-	request_object->handled = handled;	
-	if(handled){
-		//If we are handling this request with lua code, we are doing so
-		//asyncronically, which means we need to reference it now
-    	g_object_ref(G_OBJECT(request));
-	}
+    if(request_object->completed){
+        //If this request was already fulfilled synchronouly we don't need to
+        //bother with the rest  
+        request_object->handled = FALSE; //false so the request object does not get unreferenced when the lua garbage collector kicks in
+        lua_pop(L, 1 + ret);
+        if(!handled){
+            //The lua code selected files but didn't return true to handle the
+            //request, this is discouraged so throw an error
+            luaL_error(L, "select_files was called but the request wasn't explicitely handled (i.e. run_file_chooser didn't return true)");
+        }
+        return TRUE;
+    }
+    request_object->handled = handled;  
+    if(handled){
+        //If we are handling this request with lua code, we are doing so
+        //asyncronically, which means we need to reference it now
+        g_object_ref(G_OBJECT(request));
+    }
     lua_pop(L, 1 + ret);
     return handled;
 }


### PR DESCRIPTION
Hey. I added support for webkit's run-file-chooser signal, allowing users to replace the default GTK file chooser with something different (or just keep the file chooser from being shown).
I'm hoping that someone builds a file chooser that has previews and supports vim-like shortcuts (a chrome page, maybe?).

Well, back to the code. That were some of the first lines of C I ever wrote, but I'm pretty sure that I didn't fuck it up completely.... ;) 

I'll probably built some basic integrated file-manager to test what can be done with that tomorrow...

Good night :)
