### PR TITLE
fixed bug in follow command (issue #220)

### DIFF
--- a/lib/follow.lua
+++ b/lib/follow.lua
@@ -248,14 +248,13 @@ follow_js = [=[
             hints = state.hints;
 
         var hint_re = hpat && new RegExp(hpat),
-            text_re = tpat && new RegExp(tpat),
             matches = [], len = hints.length, j = 0, h;
 
         // Filter hints
         for (; i < len;) {
             h = hints[i++];
             if ((hint_re && hint_re.test(h.label)) ||
-                (text_re && text_re.test(h.text))) {
+                (h.text.indexOf(tpat) !== -1)) {
                 matches[j++] = h;
                 html += h.html;
             }


### PR DESCRIPTION
There were escaping problems when a user hits 'f'
and tries to search a term with regex special characters.
