### PR TITLE
fixed bug in follow command (issue #220, take two)

### DIFF
--- a/lib/follow.lua
+++ b/lib/follow.lua
@@ -66,20 +66,27 @@ follow_js = [=[
     function eval_selector_make_hints(selector) {
         var elems = document.querySelectorAll(selector), len = elems.length,
             win_h = window.innerHeight, win_w = window.innerWidth,
+            body_r = document.body.getClientRects()[0],
             hints = [], i = 0, j = 0, e, r, top, bottom, left, right;
 
         for (; i < len;) {
             e = elems[i++];
             r = e.getClientRects()[0];
 
+            if (!r) continue;
+
+            top = r.top - body_r.top;
+            left = r.left - body_r.left;
+            bottom = r.bottom + body_r.bottom;
+            right = r.right + body_r.right;
+
             // Check if element outside viewport
-            if (!r || (top  = r.top)  > win_h || (bottom = r.bottom) < 0
-                   || (left = r.left) > win_w || (right  = r.right)  < 0)
+            if (top > win_h || bottom < 0 || left > win_w || right < 0)
                continue;
 
             hints[j++] = { element: e, tag: e.tagName,
                 left: left, top: top,
-                width: right - left, height: bottom - top,
+                width: r.right - r.left, height: r.bottom - r.top,
                 text: e.value || e.textContent };
         }
 


### PR DESCRIPTION
There were escaping problems when a user hits 'f' and tries to search a term with regex special characters.

I took a different approach this time now that I have a better idea of what the "pattern_maker" option in follow.lua is intended for. This will prevent crashes if the javascript regex fails to compile, and will reset the last state of the pattern so that a fresh search on all tags will be performed should the user later complete the unfinished regular expression. Patterns being searched as plain-text strings should not (and have not, at least in my testing) fail to compile, so it looks like the 'regex_escape' Lua function is doing its job.
