### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ install:
 	chmod 755 $(INSTALLDIR)/share/luakit/lib/lousy/
 	chmod 755 $(INSTALLDIR)/share/luakit/lib/lousy/widget/
 	chmod 644 $(INSTALLDIR)/share/luakit/lib/*.lua
+	chmod 755 $(INSTALLDIR)/share/luakit/lib/markdown.lua
 	chmod 644 $(INSTALLDIR)/share/luakit/lib/lousy/*.lua
 	chmod 644 $(INSTALLDIR)/share/luakit/lib/lousy/widget/*.lua
 	install -d $(INSTALLDIR)/bin


### PR DESCRIPTION
While performing a lintian check on the Debian package of luakit, it saw that markdown.lua was a scipt and needed to be marke as executable. This request adds that to the Makefile.