### PR TITLE
Fallback if link center has no target

### DIFF
--- a/lib/follow_wm.lua
+++ b/lib/follow_wm.lua
@@ -24,7 +24,10 @@ local evaluators = {
         if element.child_count > 0 then
             local r = element.rect
             local doc = element.owner_document
-            element = doc:element_from_point(r.left + r.width/2, r.top + r.height/2)
+            local center_element = doc:element_from_point(r.left + r.width/2, r.top + r.height/2)
+            if center_element.href then
+                element = center_element
+            end
             tag = element.tag_name
         end
         -- Handle <a target=_blank> indirectly; WebKit prevents opening a new


### PR DESCRIPTION
In link follow mode, the center element is assumed to be a link. However, if the center element does not return a target (href), the click has no effect. This implements a check if the determined center element has a target and falls back to the outer element if not.

This fixes a symptom that occurs for example on FreeBSD where this "link-center-determination" often(always?) not return a  link target. My assumption is, that on FreeBSD the r.right / r.width etc. will return element base on the absolut position. So something from the top left corner. In my case, I always got an "H1" element when trying to navigate to the "Issue" tab here on github, which is nowhere near the Issue link in the DOM.

