### PR TITLE
Fix for compatability with urxvt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Fixed
 
  - Fixed code-blocks in documentation being formatted incorrectly.
+ - Fixed incompatibility of `editor.lua` with urxvt.
+
+### Changed
+
+ - `editor.lua` now uses substitution strings, rather than `global` to determine which editor to open.
 
 ## [2017-07-26]
 

--- a/lib/editor.lua
+++ b/lib/editor.lua
@@ -6,7 +6,6 @@
 --
 -- @module editor
 
-local globals = require("globals")
 local capi = { luakit = luakit }
 
 local _M = {}

--- a/lib/editor.lua
+++ b/lib/editor.lua
@@ -20,8 +20,6 @@
 -- @copyright 2017 Graham Leach-Krouse
 -- @copyright 2017 Aidan Holm
 
-local capi = { luakit = luakit }
-
 local _M = {}
 
 -- substitute in common values from the environment.
@@ -71,7 +69,7 @@ _M.edit = function (file, line)
         line = line or 1,
     }
     local cmd = string.gsub(_M.editor_cmd, "{(%w+)}", subs)
-    capi.luakit.spawn(cmd)
+    luakit.spawn(cmd)
 end
 
 return _M

--- a/lib/editor.lua
+++ b/lib/editor.lua
@@ -1,32 +1,76 @@
 --- Text editor launching functionality.
 --
 -- This module is primarily for use by other Lua modules that wish to
--- allow the user to edit a particular text file. This module does not
--- have any user-facing modifications or features.
+-- allow the user to edit a particular text file. The default is to guess at the
+-- shell command to open a text editor from environment variables. To override
+-- the guess, replace `editor.cmd_string`. This can be done manually, as follows:
+--
+--     local editor = require "editor"
+--     editor.editor_cmd = "urxvt -e nvim {file} +{line}"
+--
+-- Before running the command, `{file}` will be replaced by the name of the file
+-- to be edited, and `{line}` will be replaced by the number of the line at
+-- which to begin editing. This module also supplies several builtin command
+-- strings, which can be used like this:
+--
+--     local editor = require "editor"
+--     editor.editor_cmd = editor.builtin.urxvt
 --
 -- @module editor
+-- @copyright 2017 Graham Leach-Krouse
+-- @copyright 2017 Aidan Holm
 
 local capi = { luakit = luakit }
 
 local _M = {}
 
+-- substitute in common values from the environment.
+local env_sub = function (s)
+    local subs = {
+        term =  os.getenv("TERMINAL") or "xterm",
+        editor = os.getenv("EDITOR") or "vim"
+    }
+    return string.gsub(s,"{(%w+)}", subs)
+end
+
+--- Built in substitution strings. Includes
+--
+-- * `default` (attempts to extract a terminal and editor from environment
+-- variables, and otherwise falls back to xterm and vim)
+-- * `xterm`
+-- * `urxvt`
+-- * `urxvtc`
+-- * `xdg_open`
+--
+-- @type table
+-- @readonly
+_M.builtin = {
+    default = env_sub("{term} -e '{editor} {file} +{line}'"),
+    xterm = env_sub("xterm -e {editor} {file} +{line}"),
+    urxvt = env_sub("urxvt -e {editor} {file} +{line}"),
+    urxvtc = env_sub("urxvtc -e {editor} {file} +{line}"),
+    xdg_open = env_sub("xdg-open {file}")
+}
+
+--- The shell command used to open the editor.
+--
+-- @type string
+-- @readwrite
+_M.editor_cmd = _M.builtin.default
+
 --- Edit a file in a terminal editor in a new window.
 --
 -- * Can't yet handle files with special characters in their name.
--- * Can't yet use a graphical text editor (terminal only).
 -- * Can't determine when text editor is closed.
 --
 -- @tparam string file The path of the file to edit.
--- @tparam number line The line number at which to begin editing.
+-- @tparam[opt] number line The line number at which to begin editing.
 _M.edit = function (file, line)
     local subs = {
-        term = globals.term or os.getenv("TERMINAL") or "xterm",
-        editor = globals.editor or os.getenv("EDITOR") or "vim",
         file = file,
-        line = line and " +" .. tostring(line) or "",
+        line = line or 1,
     }
-    local cmd_tmpl = "{term} -e '{editor} {file}{line}'"
-    local cmd = string.gsub(cmd_tmpl, "{(%w+)}", subs)
+    local cmd = string.gsub(_M.editor_cmd, "{(%w+)}", subs)
     capi.luakit.spawn(cmd)
 end
 


### PR DESCRIPTION
At least in xterm and urxvt, the -e flag is supposed to be followed by a command and then a series of arguments to that command. The quotes here (now removed) have the effect of forcing urxvt to read the entire string as the command, which will cause it to fail when a file or line is specified.