### PR TITLE
Open editor updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed
 
  - `editor.lua` now uses substitution strings, rather than `global` to determine which editor to open.
+ - `open_editor.lua` now uses `editor.lua` rather than always using `xdg-open`.
 
 ## [2017-07-26]
 

--- a/lib/editor.lua
+++ b/lib/editor.lua
@@ -37,7 +37,6 @@ end
 -- variables, and otherwise falls back to xterm and vim)
 -- * `xterm`
 -- * `urxvt`
--- * `urxvtc`
 -- * `xdg_open`
 --
 -- @type table
@@ -46,7 +45,6 @@ _M.builtin = {
     default = env_sub("{term} -e '{editor} {file} +{line}'"),
     xterm = env_sub("xterm -e {editor} {file} +{line}"),
     urxvt = env_sub("urxvt -e {editor} {file} +{line}"),
-    urxvtc = env_sub("urxvtc -e {editor} {file} +{line}"),
     xdg_open = env_sub("xdg-open {file}")
 }
 

--- a/lib/editor.lua
+++ b/lib/editor.lua
@@ -59,17 +59,19 @@ _M.editor_cmd = _M.builtin.default
 --- Edit a file in a terminal editor in a new window.
 --
 -- * Can't yet handle files with special characters in their name.
--- * Can't determine when text editor is closed.
 --
 -- @tparam string file The path of the file to edit.
 -- @tparam[opt] number line The line number at which to begin editing.
-_M.edit = function (file, line)
+-- @tparam[opt] function callback A callback that fires when the process spawned
+-- by the editor command exits. Arguments passed to the callback are the same as
+-- those passed to the `luakit.spawn` callback.
+_M.edit = function (file, line, callback)
     local subs = {
         file = file,
         line = line or 1,
     }
     local cmd = string.gsub(_M.editor_cmd, "{(%w+)}", subs)
-    luakit.spawn(cmd)
+    luakit.spawn(cmd, callback)
 end
 
 return _M

--- a/lib/open_editor.lua
+++ b/lib/open_editor.lua
@@ -11,6 +11,7 @@
 
 local lousy = require "lousy"
 local binds = require("binds")
+local editor = require("editor")
 local add_binds = binds.add_binds
 
 local _M = {}
@@ -57,8 +58,7 @@ local function edit_externally(w)
             f:write(s)
             f:flush()
             f:close()
-            local c = string.format("xdg-open %s", file)
-            luakit.spawn(c, editor_callback)
+            editor.edit(file, 1, editor_callback)
         end
     end })
 end


### PR DESCRIPTION
Here's the PR. I removed one of the builtins (`urxvtc`), since always exits immediately (just telling `urxvtd` to open a terminal) and won't work properly with callbacks. I figure the `urxvt` builtin should be sufficient.