### PR TITLE
Fixing the IPC socket truncation

### DIFF
--- a/ipc.c
+++ b/ipc.c
@@ -119,7 +119,7 @@ web_extension_connect_thread(gpointer UNUSED(data))
     struct sockaddr_un local, remote;
     local.sun_family = AF_UNIX;
     strcpy(local.sun_path, path);
-    int len = strlen(local.sun_path) + sizeof(local.sun_family);
+    int len = offsetof(struct sockaddr_un, sun_path) + strlen(local.sun_path);
 
     if ((sock = socket(AF_UNIX, SOCK_STREAM, 0)) == -1)
         fatal("Error calling socket(): %s", strerror(errno));
@@ -191,10 +191,6 @@ initialize_web_extensions_cb(WebKitWebContext *context, gpointer UNUSED(data))
 static void
 remove_socket_file(void)
 {
-    #if defined(__FreeBSD__)
-      // FreeBSD is missing the last character
-      socket_path[strlen(socket_path)-1] = '\0';
-    #endif
     g_mutex_lock(&socket_path_lock);
     g_unlink(socket_path);
     g_free(socket_path);


### PR DESCRIPTION
Right after I posted the workaround, I found the real solution. `offsetof(struct sockaddr_un, sun_path)` should be used to determine the lenth due to different interpretation of null terminated socket paths.

I found the solution here:
https://dev.haiku-os.org/ticket/3255

This should fix https://github.com/luakit/luakit/issues/402