### PR TITLE
Unit tests fixes

### DIFF
--- a/lib/binds.lua
+++ b/lib/binds.lua
@@ -444,7 +444,7 @@ modes.add_cmds({
     { ":c[lose]", "Close current tab.", function (w) w:close_tab() end },
     { ":print", "Print current page.", function (w) w.view:eval_js("print()", { no_return = true }) end },
     { ":stop", "Stop loading.", function (w) w.view:stop() end },
-    { ":reload", "Reload page", function (w) w:reload() end },
+    { ":reload", "Reload page.", function (w) w:reload() end },
     { ":restart", "Restart browser (reload config files).", function (w, o) w:restart(o.bang) end },
     { ":write", "Save current session.", function (w) w:save_session() end },
     { ":noh[lsearch]", "Clear search highlighting.", function (w) w:clear_search() end },
@@ -491,7 +491,7 @@ modes.add_cmds({
     { ":tabl[ast]", "Switch to last tab.", function (w) w:goto_tab(-1) end },
     { ":tabn[ext]", "Switch to the next tab.", function (w) w:next_tab() end },
     { ":tabp[revious]", "Switch to the previous tab.", function (w) w:prev_tab() end },
-    { ":tabde[tach]", "Move the current tab tab into a new window", function (w) window.new({w.view}) end },
+    { ":tabde[tach]", "Move the current tab tab into a new window.", function (w) window.new({w.view}) end },
     { ":q[uit]", "Close the current window.", function (w, o) w:close_win(o.bang) end },
 
     { ":wq[all]", "Save the session and quit.", function (w, o)

--- a/tests/async/test_clib_luakit.lua
+++ b/tests/async/test_clib_luakit.lua
@@ -101,7 +101,7 @@ T.test_website_data = function ()
         assert(not wd.fetch({"all"})["Local files"])
         test.continue()
     end)()
-    test.wait()
+    test.wait(1000)
 
     v.uri = "file:///"
     test.wait_for_view(v)

--- a/tests/lib.lua
+++ b/tests/lib.lua
@@ -23,7 +23,7 @@ function _M.wait_for_view(view)
     assert(type(view) == "widget" and view.type == "webview")
     shared_lib.traceback = debug.traceback("",2)
     repeat
-        local _, status, uri, err = _M.wait_for_signal(view, "load-status", 500)
+        local _, status, uri, err = _M.wait_for_signal(view, "load-status", 5000)
         if status == "failed" then
             local fmt = "tests.wait_for_view() failed loading '%s': %s"
             local msg = fmt:format(uri, err)


### PR DESCRIPTION
Four unit-tests failures fixed:
1. test_module_binds_have_descriptions: Some bindings are missing descriptions
2. test_undo_close_works: Timed out while waiting for signal 'load-status'
3. test_undo_close_restores_tab_history: Expected objects to be equal
4. test_website_data: Timed out while waiting