### PR TITLE
Fix linker error when running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ uninstall:
 	rm -rf $(APPDIR)/luakit.desktop $(PIXMAPDIR)/luakit.png
 
 tests/util.so: tests/util.c Makefile
-	$(CC) -fpic $(CFLAGS) $(CPPFLAGS) -shared $(LDFLAGS) $< -o $@
+	$(CC) -fpic $(CFLAGS) $(CPPFLAGS) -shared $< $(LDFLAGS) -o $@
 
 run-tests: luakit luakit.so tests/util.so
 	@$(LUA_BIN_NAME) tests/run_test.lua


### PR DESCRIPTION
Source file needs to be before LDFLAGS or `-Wl,--as-needed` will drop symbols
```
 luajit: error loading module 'tests.util' from file './tests/util.so':
        Error relocating ./tests/util.so: g_dir_make_tmp: symbol not found
stack traceback:
        [C]: at 0x9d264f8370
        [C]: in function 'require'
        tests/run_test.lua:15: in main chunk
        [C]: at 0x9d264d12e0
make: *** [Makefile:125: run-tests] Error 1
```