### PR TITLE
[WIP] partial replacement for jquery

### DIFF
--- a/lib/introspector_chrome.lua
+++ b/lib/introspector_chrome.lua
@@ -223,28 +223,41 @@ local mode_bind_template = [==[
 ]==]
 
 local main_js = [=[
-$(document).ready(function () {
-    var $body = $(document.body);
+window.onload=function () {
+    // toggle source display
+    let bindClass = document.getElementsByClassName("bind");
+    for (let b = 0; b < bindClass.length; b++) {
+        bindClass[b].onclick = function (event) {
+            let func_sourceStyle = bindClass[b].getElementsByClassName("func-source")[0].style;
+            if (func_sourceStyle.display == "none") {
+                func_sourceStyle.display = "block";
+            } else {
+                func_sourceStyle.display = "none";
+            }
+        }
+    }
 
-    $body.on("click", ".bind .linedefined", function (event) {
-        event.preventDefault();
-        var $e = $(this);
-        open_editor($e.attr("filename"), $e.attr("line"));
-        return false;
-    })
+    // open a file
+    let filenameClass = document.getElementsByClassName("filename");
+    for (let f = 0; f < filenameClass.length; l++) {
+        filenameClass[f].onclick = function (event) {
+            event.preventDefault();
+            open_editor(event.target.innerText);
+            return false;
+        }
+    }
 
-    $body.on("click", ".bind .desc a", function (event) {
-        event.stopPropagation(); // prevent source toggling
-    })
-
-    $body.on("click", ".bind", function (e) {
-        var $src = $(this).find(".func-source");
-        if ($src.is(":visible"))
-            $src.slideUp();
-        else
-            $src.slideDown();
-    })
-});
+    // open a file with a custom line
+    let linedefinedClass = document.getElementsByClassName("linedefined");
+    for (let l = 0; l < linedefinedClass.length; l++) {
+        linedefinedClass[l].onclick = function (event) {
+            event.preventDefault();
+            let t = event.target;
+            open_editor(t.getAttribute("filename"), t.getAttribute("line"));
+            return false;
+        }
+    }
+}
 ]=]
 
 local source_lines = {}


### PR DESCRIPTION
needs testing

a &lt;span&gt; tag with "clickable" class (for the appearance, but maybe as well for the js - so iterate them, and where data-filename appears, that can be made functional) (or a &lt;button&gt; tag) would be much better than using &lt;a&gt; tags
preventDefault and return false are not needed this way, but takes a deeper but easy modification...

custom attributes should have "data-" prefix for valid html5 - a search&replace can help for this

origin: https://github.com/luakit/luakit/issues/198#issuecomment-321867319

