### PR TITLE
false positive with webkit-2.17.90

### DIFF
--- a/tests/async/test_clib_luakit.lua
+++ b/tests/async/test_clib_luakit.lua
@@ -36,7 +36,7 @@ T.test_luakit_index = function ()
 end
 
 T.test_webkit_version = function ()
-    assert.is_match("^%d+%.%d+%.%d$", luakit.webkit_version,
+    assert.is_match("^%d+%.%d+%.%d+$", luakit.webkit_version,
         "Invalid format: luakit.webkit_version")
     assert.is_match("^%d+%.%d+$", luakit.webkit_user_agent_version,
         "Invalid format: luakit.webkit_user_agent_version")


### PR DESCRIPTION
the following false positive fixed:

FAIL async/test_clib_luakit / test_webkit_version
  tests/async/test_clib_luakit.lua:39: Invalid format: luakit.webkit_version
  Expected strings to match.
  Passed in:
  (string) '2.17.90'
  Expected:
  (string) '^%d+%.%d+%.%d$'
  Traceback:
  (1) /usr/share/lua/5.1/luassert/assert.lua:51 in function is_match
  (2) tests/async/test_clib_luakit.lua:39       in function [anonymous]