### PR TITLE
add a bind-match-failure warning to the window widget's hit method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
  - Added `webview` widget `hardware_acceleration_policy` property.
  - Added `webview` widget `allow_file_access_from_file_urls` and `allow_universal_access_from_file_urls` properties.
  - Added `settings` module and APIs. This replaces the `domain_props` module.
+ - Added warning when no binding is matched for input.
 
 ### Changed
 

--- a/lib/window.lua
+++ b/lib/window.lua
@@ -262,7 +262,14 @@ _M.methods = {
 
         local caught, newbuf = lousy.bind.hit(w, w.binds, mods, key, opts)
         if w.win then -- Check binding didn't cause window to exit
+            local oldbuf = (w.buffer or "") .. key
             w.buffer = newbuf
+            if not (newbuf or caught or w.ibar.input.focused or w:is_mode("insert"))
+                and type(key) == "string" and key:len() == 1 then
+                w:notify("no binding matched for " .. oldbuf)
+            elseif key ~= "Scroll" then
+                w:set_prompt()
+            end
             w:update_buf()
         end
         return caught


### PR DESCRIPTION
Here's a first pass at closing #392