### PR TITLE
Fix compilation under OpenBSD (#495)

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -77,13 +77,13 @@ endif
 
 LUA_BIN_NAMES += lua-5.1 lua5.1 lua51
 ifneq ($(USE_LUAJIT),0)
-	LUA_BIN_NAMES := luajit $(LUA_BIN_NAMES)
+	LUA_BIN_NAMES := luajit luajit51 $(LUA_BIN_NAMES)
 endif
 
 # Search for Lua binary name if not forced by user.
 ifeq ($(LUA_BIN_NAME),)
 	LUA_BIN_NAME := $(shell sh -c '(for name in $(LUA_BIN_NAMES); do \
-	       hash $$name 2>/dev/null && ($$name -v 2>&1 | grep -q "^Lua 5\.1\|^LuaJIT") && echo $$name; done) | head -n 1')
+	       hash $$name 2>/dev/null && ($$name -v 2>&1 | grep -Eq "^Lua 5\.1|^LuaJIT") && echo $$name; done) | head -n 1')
 endif
 
 ifeq ($(LUA_BIN_NAME),)


### PR DESCRIPTION
Some ugly bits: `uname_s` is now defined in the non-platform-specific part (which is, strictly speaking, now platform specific -- maybe these parts should be moved down). Also, it's weird to have only one macro `__OpenBSD__`, but none for Linux, FreeBSD, etc. (should they be added? Or is there a better way to detect the OS in cpp?). Speaking of which, I'm not sure what the effects of commenting out the `#pragma`s in `widget/webview.c` are. (Probably nothing too dramatic, and it certainly doesn't work with them in place.) Please let me know if any of this should be changed.