### PR TITLE
modes.rebind()

### DIFF
--- a/lib/lousy/bind.lua
+++ b/lib/lousy/bind.lua
@@ -438,6 +438,34 @@ function _M.remove_bind (binds, bind)
     return nil, nil
 end
 
+--- Remap a binding from a given trigger to a new trigger, optionally keeping
+-- the original binding. In both cases, the new binding will have the same
+-- options as the original binding.
+-- @tparam table binds The array of bindings to remap within.
+-- @tparam string new The new trigger to map from.
+-- @tparam string old The existing trigger to remap.
+-- @tparam[opt] boolean keep Retain the existing binding.
+-- @default `false`
+function _M.remap_bind (binds, new, old, keep)
+    assert(binds and type(binds) == "table", "invalid binds table type: " .. type(binds))
+    assert(new and type(new) == "string", "invalid bind type: " .. type(new))
+    assert(old and type(old) == "string", "invalid bind type: " .. type(old))
+    new = convert_bind_syntax(new)
+    old = convert_bind_syntax(old)
+    for _, m in ipairs(binds) do
+        if m[1] == old then
+            msg.verbose("remapping bind to %s, %s %s", new, keep and "keeping" or "removing", old)
+            if keep then
+                _M.add_bind(binds, new, m[2], m[3])
+            else
+                m[1] = new
+            end
+            return
+        end
+    end
+    msg.verbose("no bind %s to remap", old)
+end
+
 return _M
 
 -- vim: et:sw=4:ts=8:sts=4:tw=80

--- a/lib/modes.lua
+++ b/lib/modes.lua
@@ -225,7 +225,7 @@ _M.new_mode("lua", [[Execute arbitrary Lua commands within the luakit
 --         end},
 --     })
 --
--- ## Bind format
+-- # Bind format
 --
 -- Every item in the `binds` array must be a table that defines a single binding
 -- between a trigger and an action. Each entry must have the following form:
@@ -279,6 +279,40 @@ _M.remove_binds = function (mode, binds)
         local mdata = assert(_M.get_mode(name), "mode '"..name.."' doesn't exist")
         for _, bind in ipairs(binds) do
             lousy.bind.remove_bind(mdata.binds or {} , bind)
+        end
+    end
+end
+
+--- Bind an existing key or command to a new binding.
+--
+-- # Example
+--
+--     -- Add an additional zooming command binding
+--     modes.rebind("normal", {
+--         { "<Control-=>", "zi", true },
+--     })
+--
+-- # Bind format
+--
+-- Every item in the `binds` array must be a table that defines a single rebind
+-- from an existing trigger to a new one. Each entry must have the following form:
+--
+--     { new, old, keep }
+--
+-- - `new` is a string describing the combination of keys/modifiers/buttons
+--   that will trigger the associated action.
+-- - `old` is a string describing the previous trigger of the action.
+-- - `keep` is an optional argument that determines whether the existing binding
+--   should remain. Defaults to `false` if not present.
+--
+-- @tparam table|string mode The name of the mode, or an array of mode names.
+-- @tparam table binds An array of binds to remap
+_M.remap_binds = function(mode, binds)
+    mode = type(mode) ~= "table" and {mode} or mode
+    for _, name in ipairs(mode) do
+        for _, bind in ipairs(binds) do
+            local new, old, keep = unpack(bind)
+            lousy.bind.remap_bind(mdata.binds or {}, new, old, keep)
         end
     end
 end


### PR DESCRIPTION
First pass at a `rebind()`. Consider this an RFC as there are a couple decisions to make.

1. There are a few ways to expose this publicly:
    1. Implement as `lousy.binds.rebind()` with a thin wrapper in `modes.rebind()`.
    2. Implement directly as `modes.rebind()`
2. Then there are two main alternatives to what the API should be:
    1. `modes.rebind("mode", "<new>", "<old>", keep)`
    2. `modes.rebind("mode", { { "<new>", "<old>", keep } })`
        - If `lousy.binds.rebind()` exists it will still use the first option.
3. There are also a few ways to actually implement it:
    1. Using `lousy.bind.remove_bind`, but slightly suboptimal due to `keep` requiring us to
re-add it.
        - Besides being inefficient, this subtly changes the order of the bind tables.
          Not sure if anything relies on that ordering.
    2. Loop through the bind table and just reassign `m[1]` (or append depending on `keep`)
4. Should it return a boolean indicating success?