### PR TITLE
show links to all luakit:// pages in the help page

### DIFF
--- a/lib/chrome.lua
+++ b/lib/chrome.lua
@@ -9,6 +9,7 @@
 -- @copyright 2010 Fabian Streitel <karottenreibe@gmail.com>
 
 local error_page = require("error_page")
+local lousy = require("lousy")
 local webview = require("webview")
 local window = require("window")
 local wm = require_web_module("chrome_wm")
@@ -169,6 +170,12 @@ _M.stylesheet = [===[
 local handlers = {}
 local on_first_visual_handlers = {}
 local page_funcs = {}
+
+--- Retrieve a list of the currently registered luakit:// handlers.
+-- @treturn {string} A list of `luakit://` handler names, in alphabetical order.
+function _M.available_handlers()
+    return lousy.util.table.keys(handlers)
+end
 
 --- Register a chrome page URI with an associated handler function.
 -- @tparam string page The name of the chrome page to register.

--- a/lib/help_chrome.lua
+++ b/lib/help_chrome.lua
@@ -38,11 +38,18 @@ local index_html_template = [==[
             license.  It is primarily targeted at power users, developers and any people with too much time
             on their hands who want to have fine-grained control over their web browser&rsquo;s behaviour and
             interface.</p>
-        <h2>Key bindings</h2>
+        <h2>Configuration</h2>
+        <h3>Settings</h3>
+        <p>The available settings are displayed at:</p>
+        <ul>
+            <li><a href="luakit://settings/">Settings</a></li>
+        </ul>
+        <h3>Key bindings</h3>
         <p>Currently active bindings are listed in the following page.</p>
         <ul>
             <li><a href="luakit://binds/">Bindings</a></li>
         </ul>
+        {chromepageshtml}
         <h2>API Documentation</h2>
         <ul>
             <li><a href="luakit://help/doc/index.html">API Index</a></li>
@@ -78,8 +85,24 @@ local index_html_template = [==[
 </body>
 ]==]
 
+local gen_html_chrome_pages = function()
+    local links = ""
+    for _, v in ipairs(chrome.available_handlers()) do
+        links = links .. "<li><a href=\"luakit://" .. v .. "\">" .. v .. "</a></li>\n"
+    end
+    return [==[
+        <h3>luakit:// pages</h3>
+        <p>These are all the available <code>luakit://</code> pages:</p>
+        <ul>
+]==] .. links .. "</ul>"
+end
+
 local help_index_page = function ()
-    local html_subs = { style = chrome.stylesheet, version = luakit.version, }
+    local html_subs = {
+        style = chrome.stylesheet,
+        version = luakit.version,
+        chromepageshtml = gen_html_chrome_pages(),
+    }
     local html = string.gsub(index_html_template, "{(%w+)}", html_subs)
     return html
 end


### PR DESCRIPTION
Hello,

I've re-installed luakit, and spent quite a good time trying to figure out how to configure it. I changed the documentation so it shows all the available chrome pages, so others don't have to dig that much to get to the config. facilities/new features available.

It's been a while since I wrote Lua; sorry for the lack of style.

Now the help page looks like this: https://imgur.com/rNt0fuV