### PR TITLE
correct escaping of HTML entities in documentation pages

### DIFF
--- a/build-utils/docgen/gen.lua
+++ b/build-utils/docgen/gen.lua
@@ -33,12 +33,13 @@ local format_text = function (text)
     -- Format with markdown
     ret = markdown(ret)
     ret = ret:gsub("<pre><code>(.-)</code></pre>", function (code)
-        -- Fix < and > being escaped inside code -_- fail
-        code = lousy.util.unescape(code)
         -- Add syntax highlighting if lxsh is installed
         local ok, lxsh = pcall(require, "lxsh")
         if ok then
-            code = lxsh.highlighters.lua(code, { formatter = lxsh.formatters.html, external = true })
+            code = lxsh.highlighters.lua(
+                lousy.util.unescape(code),  -- Fix < and > being escaped inside code -_- fail
+                { formatter = lxsh.formatters.html, external = true }
+            )
         else
             code = "<pre class='sourcecode lua'>" .. code .. "</pre>"
         end


### PR DESCRIPTION
when the lxsh rock is not available, the HTML escaping must be kept, or
else the text in code samples is not rendered correctly when it contains
HTML special chars.

E.g., the "FAQ" page used to look like this (html in examples does not render properly): https://imgur.com/a/J4IzQ

and now, after the change (html in code examples renders properly): https://imgur.com/a/BuBJO
