### PR TITLE
Improve mechanism of opening selection contents

### DIFF
--- a/lib/binds.lua
+++ b/lib/binds.lua
@@ -241,16 +241,13 @@ modes.add_binds("normal", {
     -- Open primary selection contents.
     { "pp", [[Open URLs based on the current primary selection contents in the current tab.]],
         function (w)
-            local uris = {}
-            for uri in string.gmatch(luakit.selection.primary or "", "%S+") do
-                table.insert(uris, uri)
-            end
-            if #uris == 0 then w:notify("Nothing in primary selection...") return end
-            w:navigate(w:search_open(uris[1]))
-            if #uris > 1 then
-                for i=2,#uris do
-                    w:new_tab(w:search_open(uris[i]))
-                end
+            local uris = lousy.uri.split(luakit.selection.primary or "")
+            i, uri = next(uris)
+            if not i then w:notify("Nothing in primary selection...") return end
+            w:navigate(w:search_open(uri))
+            while next(uris, i) do
+                i, uri = next(uris, i)
+                w:new_tab(w:search_open(uri))
             end
         end },
     { "pt", [[Open a URL based on the current primary selection contents in `[count=1]` new tab(s).]],
@@ -261,32 +258,26 @@ modes.add_binds("normal", {
         end, {count = 1} },
     { "^pw$", [[Open URLs based on the current primary selection contents in a new window.]],
         function(w)
-            local uris = {}
-            for uri in string.gmatch(luakit.selection.primary or "", "%S+") do
-                table.insert(uris, uri)
-            end
-            if #uris == 0 then w:notify("Nothing in primary selection...") return end
-            w = window.new{w:search_open(uris[1])}
-            if #uris > 1 then
-                for i=2,#uris do
-                    w:new_tab(w:search_open(uris[i]))
-                end
+            local uris = lousy.uri.split(luakit.selection.primary or "")
+            i, uri = next(uris)
+            if not i then w:notify("Nothing in primary selection...") return end
+            w = window.new{w:search_open(uri)}
+            while next(uris, i) do
+                i, uri = next(uris, i)
+                w:new_tab(w:search_open(uri))
             end
         end },
 
     -- Open clipboard contents.
     { "^PP$", [[Open URLs based on the current clipboard selection contents in the current tab.]],
         function (w)
-            local uris = {}
-            for uri in string.gmatch(luakit.selection.clipboard or "", "%S+") do
-                table.insert(uris, uri)
-            end
-            if #uris == 0 then w:notify("Nothing in clipboard...") return end
-            w:navigate(w:search_open(uris[1]))
-            if #uris > 1 then
-                for _=2,#uris do
-                    w:new_tab(w:search_open(uris[1]))
-                end
+            local uris = lousy.uri.split(luakit.selection.clipboard or "")
+            i, uri = next(uris)
+            if not i then w:notify("Nothing in clipboard...") return end
+            w:navigate(w:search_open(uri))
+            while next(uris, i) do
+                i, uri = next(uris, i)
+                w:new_tab(w:search_open(uri))
             end
         end },
 
@@ -299,16 +290,13 @@ modes.add_binds("normal", {
 
     { "^PW$", [[Open URLs based on the current clipboard selection contents in a new window.]],
         function(w)
-            local uris = {}
-            for uri in string.gmatch(luakit.selection.clipboard or "", "%S+") do
-                table.insert(uris, uri)
-            end
-            if #uris == 0 then w:notify("Nothing in clipboard...") return end
-            w = window.new{w:search_open(uris[1])}
-            if #uris > 1 then
-                for i=2,#uris do
-                    w:new_tab(w:search_open(uris[i]))
-                end
+            local uris = lousy.uri.split(luakit.selection.clipboard or "")
+            i, uri = next(uris)
+            if not i then w:notify("Nothing in clipboard...") return end
+            w = window.new{w:search_open(uri)}
+            while next(uris, i) do
+                i, uri = next(uris, i)
+                w:new_tab(w:search_open(uri))
             end
         end },
 

--- a/lib/binds.lua
+++ b/lib/binds.lua
@@ -247,8 +247,8 @@ modes.add_binds("normal", {
             local engine = settings.get_setting("window.default_search_engine")
             local uris = split_uri(luakit.selection.primary or "")
             if #uris == 0 then w:notify("Nothing in primary selection...") return end
-            local uri = table.remove(uris, 1)
-            w:navigate(is_uri(uri) and uri or w:search_open(engine .. uri))
+            local uri1 = table.remove(uris, 1)
+            w:navigate(is_uri(uri1) and uri1 or w:search_open(engine .. uri1))
             for _, uri in ipairs(uris) do
                 w:new_tab(is_uri(uri) and uri or w:search_open(engine .. uri))
             end
@@ -267,8 +267,8 @@ modes.add_binds("normal", {
             local engine = settings.get_setting("window.default_search_engine")
             local uris = split_uri(luakit.selection.primary or "")
             if #uris == 0 then w:notify("Nothing in primary selection...") return end
-            local uri = table.remove(uris, 1)
-            w = window.new{is_uri(uri) and uri or w:search_open(engine .. uri)}
+            local uri1 = table.remove(uris, 1)
+            w = window.new{is_uri(uri1) and uri1 or w:search_open(engine .. uri1)}
             for _, uri in ipairs(uris) do
                 w:new_tab(is_uri(uri) and uri or w:search_open(engine .. uri))
             end
@@ -280,8 +280,8 @@ modes.add_binds("normal", {
             local engine = settings.get_setting("window.default_search_engine")
             local uris = split_uri(luakit.selection.clipboard or "")
             if #uris == 0 then w:notify("Nothing in primary selection...") return end
-            local uri = table.remove(uris, 1)
-            w:navigate(is_uri(uri) and uri or w:search_open(engine .. uri))
+            local uri1 = table.remove(uris, 1)
+            w:navigate(is_uri(uri1) and uri1 or w:search_open(engine .. uri1))
             for _, uri in ipairs(uris) do
                 w:new_tab(is_uri(uri) and uri or w:search_open(engine .. uri))
             end
@@ -300,8 +300,8 @@ modes.add_binds("normal", {
             local engine = settings.get_setting("window.default_search_engine")
             local uris = split_uri(luakit.selection.clipboard or "")
             if #uris == 0 then w:notify("Nothing in clipboard...") return end
-            local uri = table.remove(uris, 1)
-            w = window.new{is_uri(uri) and uri or w:search_open(engine .. uri)}
+            local uri1 = table.remove(uris, 1)
+            w = window.new{is_uri(uri1) and uri1 or w:search_open(engine .. uri1)}
             for _, uri in ipairs(uris) do
                 w:new_tab(is_uri(uri) and uri or w:search_open(engine .. uri))
             end

--- a/lib/binds.lua
+++ b/lib/binds.lua
@@ -22,6 +22,9 @@ local modes = require("modes")
 -- Util aliases
 local join, split = lousy.util.table.join, lousy.util.string.split
 
+-- URI aliases
+local is_uri, split_uri = lousy.uri.is_uri, lousy.uri.split
+
 --- Compatibility wrapper for @ref{modes/add_binds|modes.add_binds()}.
 -- @deprecated use @ref{modes/add_binds|modes.add_binds()} instead.
 _M.add_binds = function (...)
@@ -241,62 +244,66 @@ modes.add_binds("normal", {
     -- Open primary selection contents.
     { "pp", [[Open URLs based on the current primary selection contents in the current tab.]],
         function (w)
-            local uris = lousy.uri.split(luakit.selection.primary or "")
-            i, uri = next(uris)
-            if not i then w:notify("Nothing in primary selection...") return end
-            w:navigate(w:search_open(uri))
-            while next(uris, i) do
-                i, uri = next(uris, i)
-                w:new_tab(w:search_open(uri))
+            local engine = settings.get_setting("window.default_search_engine")
+            local uris = split_uri(luakit.selection.primary or "")
+            if #uris == 0 then w:notify("Nothing in primary selection...") return end
+            local uri = table.remove(uris, 1)
+            w:navigate(is_uri(uri) and uri or w:search_open(engine .. uri))
+            for _, uri in ipairs(uris) do
+                w:new_tab(is_uri(uri) and uri or w:search_open(engine .. uri))
             end
         end },
-    { "pt", [[Open a URL based on the current primary selection contents in `[count=1]` new tab(s).]],
-            function (w, _, m)
-                local uri = luakit.selection.primary
-                if not uri then w:notify("No primary selection...") return end
-                for _ = 1, m.count do w:new_tab(w:search_open(uri)) end
-        end, {count = 1} },
-    { "^pw$", [[Open URLs based on the current primary selection contents in a new window.]],
-        function(w)
-            local uris = lousy.uri.split(luakit.selection.primary or "")
-            i, uri = next(uris)
-            if not i then w:notify("Nothing in primary selection...") return end
-            w = window.new{w:search_open(uri)}
-            while next(uris, i) do
-                i, uri = next(uris, i)
-                w:new_tab(w:search_open(uri))
+    { "pt", [[Open URLs based on the current primary selection contents in new tabs.]],
+        function (w)
+            local engine = settings.get_setting("window.default_search_engine")
+            local uris = split_uri(luakit.selection.primary or "")
+            if #uris == 0 then w:notify("Nothing in primary selection...") return end
+            for _, uri in ipairs(uris) do
+                w:new_tab(is_uri(uri) and uri or w:search_open(engine .. uri))
+            end
+        end },
+    { "pw", [[Open URLs based on the current primary selection contents in a new window.]],
+        function (w)
+            local engine = settings.get_setting("window.default_search_engine")
+            local uris = split_uri(luakit.selection.primary or "")
+            if #uris == 0 then w:notify("Nothing in primary selection...") return end
+            local uri = table.remove(uris, 1)
+            w = window.new{is_uri(uri) and uri or w:search_open(engine .. uri)}
+            for _, uri in ipairs(uris) do
+                w:new_tab(is_uri(uri) and uri or w:search_open(engine .. uri))
             end
         end },
 
     -- Open clipboard contents.
-    { "^PP$", [[Open URLs based on the current clipboard selection contents in the current tab.]],
+    { "PP", [[Open URLs based on the current clipboard selection contents in the current tab.]],
         function (w)
-            local uris = lousy.uri.split(luakit.selection.clipboard or "")
-            i, uri = next(uris)
-            if not i then w:notify("Nothing in clipboard...") return end
-            w:navigate(w:search_open(uri))
-            while next(uris, i) do
-                i, uri = next(uris, i)
-                w:new_tab(w:search_open(uri))
+            local engine = settings.get_setting("window.default_search_engine")
+            local uris = split_uri(luakit.selection.clipboard or "")
+            if #uris == 0 then w:notify("Nothing in primary selection...") return end
+            local uri = table.remove(uris, 1)
+            w:navigate(is_uri(uri) and uri or w:search_open(engine .. uri))
+            for _, uri in ipairs(uris) do
+                w:new_tab(is_uri(uri) and uri or w:search_open(engine .. uri))
             end
         end },
-
-    { "^PT$", [[Open a URL based on the current clipboard selection contents in `[count=1]` new tab(s).]],
-        function (w, _, m)
-            local uri = luakit.selection.clipboard
-            if not uri then w:notify("Nothing in clipboard...") return end
-            for _ = 1, m.count do w:new_tab(w:search_open(uri)) end
-    end, {count = 1} },
-
-    { "^PW$", [[Open URLs based on the current clipboard selection contents in a new window.]],
-        function(w)
-            local uris = lousy.uri.split(luakit.selection.clipboard or "")
-            i, uri = next(uris)
-            if not i then w:notify("Nothing in clipboard...") return end
-            w = window.new{w:search_open(uri)}
-            while next(uris, i) do
-                i, uri = next(uris, i)
-                w:new_tab(w:search_open(uri))
+    { "PT", [[Open URLs based on the current clipboard selection contents in new tabs.]],
+        function (w)
+            local engine = settings.get_setting("window.default_search_engine")
+            local uris = split_uri(luakit.selection.clipboard or "")
+            if #uris == 0 then w:notify("Nothing in clipboard...") return end
+            for _, uri in ipairs(uris) do
+                w:new_tab(is_uri(uri) and uri or w:search_open(engine .. uri))
+            end
+        end },
+    { "PW", [[Open URLs based on the current clipboard selection contents in a new window.]],
+        function (w)
+            local engine = settings.get_setting("window.default_search_engine")
+            local uris = split_uri(luakit.selection.clipboard or "")
+            if #uris == 0 then w:notify("Nothing in clipboard...") return end
+            local uri = table.remove(uris, 1)
+            w = window.new{is_uri(uri) and uri or w:search_open(engine .. uri)}
+            for _, uri in ipairs(uris) do
+                w:new_tab(is_uri(uri) and uri or w:search_open(engine .. uri))
             end
         end },
 

--- a/lib/lousy/uri.lua
+++ b/lib/lousy/uri.lua
@@ -68,6 +68,8 @@ function _M.is_uri(s)
         return true
     end
 
+    -- Only file URI may have leading punctuation
+    if s:find("^%p") then return false end
     if s == "about:blank" or s:find("[%./]") or s:find("^javascript:") then
         return true
     end

--- a/lib/window.lua
+++ b/lib/window.lua
@@ -599,9 +599,8 @@ _M.methods = {
         local args = lstring.split(arg)
 
         -- Guess if single argument is an address, etc.
-        if #args == 1 then
-            local arg = args[1]
-            if not search_engines[arg] and lousy.uri.is_uri(arg) then return arg end
+        if #args == 1 and not search_engines[arg] and lousy.uri.is_uri(arg) then
+            return arg
         end
 
         -- Find search engine (or use default_search_engine)

--- a/lib/window.lua
+++ b/lib/window.lua
@@ -581,11 +581,10 @@ _M.methods = {
     -- Intelligent open command which can detect a uri or search argument.
     search_open = function (_, arg)
         local lstring = lousy.util.string
-        local match, find = string.match, string.find
         local search_engines = settings.get_setting("window.search_engines")
 
         -- Detect blank uris
-        if not arg or match(arg, "^%s*$") then return settings.get_setting("window.new_tab_page") end
+        if not arg or arg:match("^%s*$") then return settings.get_setting("window.new_tab_page") end
 
         arg = lstring.strip(arg)
 
@@ -599,27 +598,10 @@ _M.methods = {
 
         local args = lstring.split(arg)
 
-        -- Guess if single argument is an address, etc
-        if #args == 1 and not search_engines[args[1]] then
-            local uri = args[1]
-            if uri == "about:blank" then return uri end
-
-            -- Navigate if . or / in uri (I.e. domains, IP's, scheme://)
-            if find(uri, "%.") or find(uri, "/") then return uri end
-
-            -- Navigate if this is a javascript-uri
-            if find(uri, "^javascript:") then return uri end
-
-            -- Valid hostnames to check
-            local hosts = { "localhost" }
-            if settings.get_setting("window.load_etc_hosts") then
-                hosts = lousy.util.get_etc_hosts()
-            end
-
-            -- Check hostnames
-            for _, h in pairs(hosts) do
-                if h == uri or match(uri, "^"..h..":%d+$") then return uri end
-            end
+        -- Guess if single argument is an address, etc.
+        if #args == 1 then
+            local arg = args[1]
+            if not search_engines[arg] and lousy.uri.is_uri(arg) then return arg end
         end
 
         -- Find search engine (or use default_search_engine)

--- a/tests/async/test_lib_lousy_uri.lua
+++ b/tests/async/test_lib_lousy_uri.lua
@@ -22,6 +22,12 @@ T.test_lousy_uri_properties = function ()
     end
 end
 
+T.test_lousy_uri_parse_is_uri = function()
+    local is_uri = lousy.uri.is_uri
+    assert.is_true(
+    -- File URIs can't be tested here because they are system-dependant
+end
+
 T.test_lousy_uri_parse = function ()
     local uri = "http://test-user:p4ssw0rd@example.com:777/some~path?a=b&foo=bar#frag"
     local uri_without_password = "http://test-user@example.com:777/some~path?a=b&foo=bar#frag"


### PR DESCRIPTION
Fixes #642.

Although `lousy.uri.split` is only used in `binds`, I keep it in `lousy.uri` to allow users to use it in their config (e.g. `:open` with `pp` mechanism).