### PR TITLE
Warning for deprecated config files (see #620).

### DIFF
--- a/config/rc.lua
+++ b/config/rc.lua
@@ -4,8 +4,12 @@
 
 require "lfs"
 
-local old_require = require
-local function require (module)
+-- Checks whether there exist module files in the local config dir and warns
+-- that it's deprecated, unless you really want to use them. It's not really a
+-- searchers function, it simply issues a warning, then the next function in
+-- package.searchers is used to load the module.
+local searchers = package.searchers or package.loaders
+local function deprecated_files (module)
     local f = package.searchpath(module, package.path)
     local lf = luakit.config_dir .. "/" .. module .. ".lua"
     if f ==  lf then
@@ -15,10 +19,8 @@ local function require (module)
             .. " for core module '" .. module
             .. "', but it won't be used, unless you update 'package.path' accordingly.")
     end
-
-    local r = old_require(module)
-    return r
 end
+table.insert(searchers, 2, deprecated_files) 
 
 require "unique_instance"
 
@@ -177,11 +179,21 @@ local tab_favicons = require "tab_favicons"
 -- Add :view-source command
 local view_source = require "view_source"
 
+-- Perhaps paranoid, but you never know.
+local i
+for j, f in ipairs(searchers) do
+    if f == deprecated_files then
+        i = j
+        break
+    end
+end
+if i then table.remove(searchers, i) end
+
 -- Put "userconf.lua" in your Luakit config dir with your own tweaks; if this is
 -- permanent, no need to copy/paste/modify the default rc.lua whenever you
 -- update Luakit.
 if pcall(function () lousy.util.find_config("userconf.lua") end) then
-    old_require "userconf"
+    require "userconf"
 end
 
 -----------------------------

--- a/config/rc.lua
+++ b/config/rc.lua
@@ -4,6 +4,22 @@
 
 require "lfs"
 
+local old_require = require
+local function require (module)
+    local f = package.searchpath(module, package.path)
+    local lf = luakit.config_dir .. "/" .. module .. ".lua"
+    if f ==  lf then
+        msg.warn("Loading local version of '" .. module .. "' module: " .. lf)
+    elseif lfs.attributes(lf) then
+        msg.warn("Found local version " .. lf
+            .. " for core module '" .. module
+            .. "', but it won't be used, unless you update 'package.path' accordingly.")
+    end
+
+    local r = old_require(module)
+    return r
+end
+
 require "unique_instance"
 
 -- Set the number of web processes to use. A value of 0 means 'no limit'.
@@ -165,7 +181,7 @@ local view_source = require "view_source"
 -- permanent, no need to copy/paste/modify the default rc.lua whenever you
 -- update Luakit.
 if pcall(function () lousy.util.find_config("userconf.lua") end) then
-    require "userconf"
+    old_require "userconf"
 end
 
 -----------------------------


### PR DESCRIPTION
This addresses #620.

Overloading `require()` might not be a good idea, but this is a first draft. Also, I guess the warning could be reworded.