### PR TITLE
Add permanent history to command-line

### DIFF
--- a/lib/cmdhist.lua
+++ b/lib/cmdhist.lua
@@ -75,15 +75,13 @@ window.add_signal("init", function (w)
             local h = mode.history
             -- Load history
             if not h.items then
-                local items = {}
-                local f = io.open(luakit.data_dir .. "/" .. mode.name .. "-history")
+                local f = io.open(luakit.data_dir .. "/command-history")
                 if f then
-                    for l in f:lines() do
-                        table.insert(items, l)
-                    end
+                    h.items = lousy.pickle.unpickle(f:read("*a"))[mode.name]
                     f:close()
                 end
-                h.items = items
+                -- The function could return if history is empty
+                h.items = h.items or {}
             end
             h.len = #(h.items)
             h.cursor = nil

--- a/lib/cmdhist.lua
+++ b/lib/cmdhist.lua
@@ -61,7 +61,18 @@ window.add_signal("init", function (w)
         -- Setup history state
         if mode and mode.history then
             local h = mode.history
-            if not h.items then h.items = {} end
+            -- Load history
+            if not h.items then
+                local items = {}
+                local f = io.open(luakit.data_dir .. "/" .. mode.name .. "-history")
+                if f then
+                    for l in f:lines() do
+                        table.insert(items, l)
+                    end
+                    f:close()
+                end
+                h.items = items
+            end
             h.len = #(h.items)
             h.cursor = nil
             h.orig = nil

--- a/lib/cmdhist.lua
+++ b/lib/cmdhist.lua
@@ -27,30 +27,42 @@ _M.history_prev = "<Up>"
 -- @readwrite
 _M.history_next = "<Down>"
 
+local function filter (t, f)
+    local T = {}
+    for _, v in ipairs(t) do
+        if v:find(f, 1, true) then
+            table.insert(T, v)
+        end
+    end
+    return T
+end
+
 local history_prev_func = function (w)
     local h = w.mode.history
+    h.filtered = h.filtered or filter(h.items, w.ibar.input.text)
     local lc = h.cursor
-    if not h.cursor and h.len > 0 then
-        h.cursor = h.len
+    if not h.cursor and #h.filtered > 0 then
+        h.cursor = #h.filtered
     elseif (h.cursor or 0) > 1 then
         h.cursor = h.cursor - 1
     end
     if h.cursor and h.cursor ~= lc then
         if not h.orig then h.orig = w.ibar.input.text end
-        w:set_input(h.items[h.cursor])
+        w:set_input(h.filtered[h.cursor])
     end
 end
 
 local history_next_func = function (w)
     local h = w.mode.history
     if not h.cursor then return end
-    if h.cursor >= h.len then
+    if h.cursor >= #h.filtered then
         w:set_input(h.orig)
         h.cursor = nil
         h.orig = nil
+        h.filtered = nil
     else
         h.cursor = h.cursor + 1
-        w:set_input(h.items[h.cursor])
+        w:set_input(h.filtered[h.cursor])
     end
 end
 
@@ -76,6 +88,7 @@ window.add_signal("init", function (w)
             h.len = #(h.items)
             h.cursor = nil
             h.orig = nil
+            h.filtered = nil
             -- Add Prev & Next history bindings
             local hist_binds = {{_M.history_prev, history_prev_func},
                 {_M.history_next, history_next_func}}

--- a/lib/modes.lua
+++ b/lib/modes.lua
@@ -105,9 +105,15 @@ window.add_signal("init", function (w)
             if not w.view.private and hist and hist.items and hist.items[hist.len or -1] ~= text then
                 table.insert(hist.items, text)
                 -- Dump history
-                local f = io.open(luakit.data_dir .. "/" .. mode.name .. "-history", "w")
+                local t = {}
+                for k, v in pairs(modes) do
+                    if v.history then
+                        t[k] = v.history.items
+                    end
+                end
+                local f = io.open(luakit.data_dir .. "/command-history", "w")
                 if f then
-                    f:write(table.concat(hist.items, "\n"))
+                    f:write(lousy.pickle.pickle(t))
                     f:close()
                 end
             end

--- a/lib/modes.lua
+++ b/lib/modes.lua
@@ -101,8 +101,8 @@ window.add_signal("init", function (w)
         if mode and mode.activate then
             local text, hist = input.text, mode.history
             if mode.activate(w, text) == false then return end
-            -- Check if last history item is identical
-            if hist and hist.items and hist.items[hist.len or -1] ~= text then
+            -- Check if last history item should be recorded.
+            if not w.view.private and hist and hist.items and hist.items[hist.len or -1] ~= text then
                 table.insert(hist.items, text)
                 -- Dump history
                 local f = io.open(luakit.data_dir .. "/" .. mode.name .. "-history", "w")

--- a/lib/modes.lua
+++ b/lib/modes.lua
@@ -104,7 +104,7 @@ window.add_signal("init", function (w)
             if mode.activate(w, text) == false then return end
             -- Prevents recording command history if in a private tab, or
             -- recording the `:priv-tabopen` command itself.
-            if w.view.private then return end
+            if w.view and w.view.private then return end
             local hist = mode.history
             -- Check if last history is identical
             if hist and hist.items and hist.items[hist.len or -1] ~= text then

--- a/lib/modes.lua
+++ b/lib/modes.lua
@@ -104,6 +104,12 @@ window.add_signal("init", function (w)
             -- Check if last history item is identical
             if hist and hist.items and hist.items[hist.len or -1] ~= text then
                 table.insert(hist.items, text)
+                -- Dump history
+                local f = io.open(luakit.data_dir .. "/" .. mode.name .. "-history", "w")
+                if f then
+                    f:write(table.concat(hist.items, "\n"))
+                    f:close()
+                end
             end
         end
     end)

--- a/lib/modes.lua
+++ b/lib/modes.lua
@@ -99,10 +99,15 @@ window.add_signal("init", function (w)
     input:add_signal("activate", function ()
         local mode = w.mode
         if mode and mode.activate then
-            local text, hist = input.text, mode.history
+            local text = input.text
+            -- Activates the mode.
             if mode.activate(w, text) == false then return end
-            -- Check if last history item should be recorded.
-            if not w.view.private and hist and hist.items and hist.items[hist.len or -1] ~= text then
+            -- Prevents recording command history if in a private tab, or
+            -- recording the `:priv-tabopen` command itself.
+            if w.view.private then return end
+            local hist = mode.history
+            -- Check if last history is identical
+            if hist and hist.items and hist.items[hist.len or -1] ~= text then
                 table.insert(hist.items, text)
                 -- Dump history
                 local t = {}


### PR DESCRIPTION
This makes command/lua modes history permanent, i.e. it persists between invocations. It requires creating the `luakit.data_dir/(command|lua)-history` files.

It would be more elegant to rewrite the files when Luakit closes, but I wanted to keep the modifications where history operations already appear, at least for the moment. Actually, I'd rather:

1. Leave `cmdhist.lua` as is
1. Load history when the two modes are defined
3. Record history in the `activate` method of each mode (and perhaps dump it there too)
4. Get rid of the `activate` signal for the `input` object, which, if I'm not mistaken, has no other use (that would also require rewriting the `window:activate()` method, but it's no big deal)