### PR TITLE
Abbreviate search engine names.

### DIFF
--- a/lib/window.lua
+++ b/lib/window.lua
@@ -832,7 +832,7 @@ settings.register_settings({
     },
     ["window.search_engine_min_length"] = {
         type = "number", min = 1,
-        default = 2,
+        default = 100,
         desc = "How many letters make a valid search engine abbreviation.",
     },
     ["window.scroll_step"] = {

--- a/lib/window.lua
+++ b/lib/window.lua
@@ -280,6 +280,16 @@ local init_funcs = {
     end,
 }
 
+local table_keys, filter_array = lousy.util.table.keys, lousy.util.table.filter_array
+local function check_search_engine (str)
+    if not str or #str < settings.get_setting("window.search_engine_min_length") then return end
+    local engines = table_keys(settings.get_setting("window.search_engines"))
+    local t = filter_array(engines, function (_, n)
+        return n:sub(1, #str) == str
+    end)
+    return t[1]
+end
+
 --- Helper functions which operate on the window widgets or structure.
 -- @type {[string]=function}
 -- @readwrite
@@ -581,7 +591,6 @@ _M.methods = {
     -- Intelligent open command which can detect a uri or search argument.
     search_open = function (_, arg)
         local lstring = lousy.util.string
-        local search_engines = settings.get_setting("window.search_engines")
 
         -- Detect blank uris
         if not arg or arg:match("^%s*$") then return settings.get_setting("window.new_tab_page") end
@@ -598,17 +607,20 @@ _M.methods = {
         local args = lstring.split(arg)
 
         -- Guess if single argument is an address, etc.
-        if #args == 1 and not search_engines[arg] and lousy.uri.is_uri(arg) then
+        local engine_name = check_search_engine(args[1])
+        if #args == 1 and not engine_name and lousy.uri.is_uri(arg) then
             return arg
         end
 
         -- Find search engine (or use default_search_engine)
-        local engine = settings.get_setting("window.default_search_engine")
-        if args[1] and search_engines[args[1]] then
-            engine = args[1]
+        local engine
+        if engine_name then
+            engine = engine_name
             table.remove(args, 1)
+        else
+            engine = settings.get_setting("window.default_search_engine")
         end
-        local e = search_engines[engine] or "%s"
+        local e = settings.get_setting("window.search_engines")[engine] or "%s"
 
         local terms = table.concat(args, " ")
         if type(e) == "string" then
@@ -817,6 +829,11 @@ settings.register_settings({
 
             Must be a key of `window.search_engines`.
         ]=],
+    },
+    ["window.search_engine_min_length"] = {
+        type = "number", min = 1,
+        default = 2,
+        desc = "How many letters make a valid search engine abbreviation.",
     },
     ["window.scroll_step"] = {
         type = "number", min = 0,

--- a/lib/window.lua
+++ b/lib/window.lua
@@ -282,7 +282,8 @@ local init_funcs = {
 
 local table_keys, filter_array = lousy.util.table.keys, lousy.util.table.filter_array
 local function check_search_engine (str)
-    if not str or #str < settings.get_setting("window.search_engine_min_length") then return end
+    local l = settings.get_setting("window.search_engine_min_length")
+    if not str or l < 1 or #str < l then return end
     local engines = table_keys(settings.get_setting("window.search_engines"))
     local t = filter_array(engines, function (_, n)
         return n:sub(1, #str) == str
@@ -832,8 +833,12 @@ settings.register_settings({
     },
     ["window.search_engine_min_length"] = {
         type = "number", min = 1,
-        default = 100,
-        desc = "How many letters make a valid search engine abbreviation.",
+        default = 0,
+        desc = [=[
+            How many letters make a valid search engine abbreviation.
+
+            A nonpositive value disables abbreviations.
+        ]=],
     },
     ["window.scroll_step"] = {
         type = "number", min = 0,


### PR DESCRIPTION
When you have e.g. `wikipedia` defined as a search engine, it is much more convenient to type only `:open wi something` or `:open wiki something` than the full engine's name.

To do that, I had a loop in `userconf.lua` to create the `w`, `wi`, `wik` ... `wikipedia` search engines. But it is highly unelegant, and it makes the `searchmenu` plugins unusable.

This allows typing only the first letters of a search engine. The minimal number of letters is set with `window.search_engine_min_length`, so a large value can totally disable abbreviations.