### PR TITLE
Fix URI/title swap in completion.

### DIFF
--- a/lib/completion.lua
+++ b/lib/completion.lua
@@ -331,7 +331,7 @@ completers.history = {
 
         for _, row in ipairs(rows) do
             table.insert(ret, {
-                escape(row.title), escape(row.uri),
+                escape(row.title) or "", escape(row.uri),
                 format = {{ lit = row.uri }},
                 buf = row.uri
             })


### PR DESCRIPTION
For some reason, when the completion menu encounters an item without a title, it puts the URI in its place, and then titles and URI's are swapped for all items, included those already encountered in the menu and in later completion.

Since `completion.lua` is pretty obscure to me, this is a simple fix (simple forbid null titles). Perhaps something other than the empty string would be better, though. For bookmarks, null titles are replaced with URI's, apparently (I never use bookmarks), but I'm not sure it's readable.