### PR TITLE
Do not destroy() the current view, workaround for issue #725

### DIFF
--- a/lib/window.lua
+++ b/lib/window.lua
@@ -481,7 +481,6 @@ _M.methods = {
         view = view or w.view
         w:emit_signal("close-tab", view)
         w:detach_tab(view, blank_last)
-        view:destroy()
     end,
 
     attach_tab = function (w, view, switch, order)


### PR DESCRIPTION
When just one tab is present it leads to an high CPU usage and luakit completely
stuck (although start luakit via `--log=DEBUG' option shows that it responds to
events).