### PR TITLE
Change default directories to be only accessible by the owner

### DIFF
--- a/luakit.c
+++ b/luakit.c
@@ -45,9 +45,9 @@ init_directories(void)
     globalconf.cache_dir  = g_build_filename(g_get_user_cache_dir(),  "luakit", globalconf.profile, NULL);
     globalconf.config_dir = g_build_filename(g_get_user_config_dir(), "luakit", globalconf.profile, NULL);
     globalconf.data_dir   = g_build_filename(g_get_user_data_dir(),   "luakit", globalconf.profile, NULL);
-    g_mkdir_with_parents(globalconf.cache_dir,  0771);
-    g_mkdir_with_parents(globalconf.config_dir, 0771);
-    g_mkdir_with_parents(globalconf.data_dir,   0771);
+    g_mkdir_with_parents(globalconf.cache_dir,  0700);
+    g_mkdir_with_parents(globalconf.config_dir, 0700);
+    g_mkdir_with_parents(globalconf.data_dir,   0700);
 }
 
 static void


### PR DESCRIPTION
This is an alternative approach to PR https://github.com/luakit/luakit/pull/728

Changing default directory permissions for data / cache / config directory from 771 to 700. This is a better default and will protect possibly sensitive files like browser cache, formfiller.lua and cookie.db.
