### PR TITLE
Show nicer error when calling :js without argument

### DIFF
--- a/lib/binds.lua
+++ b/lib/binds.lua
@@ -489,12 +489,18 @@ modes.add_cmds({
         format = "{uri}",
     }},
     { ":javascript, :js", "Evaluate JavaScript snippet.",
-        function (w, o) w.view:eval_js(o.arg, {
+        function (w, o)
+            if o.arg then
+                w.view:eval_js(o.arg, {
                     no_return = true,
                     callback = function (_, err)
                         w:error(err)
                     end,
-                }) end },
+                }) 
+            else
+                w:error("No argument provided")
+            end
+        end },
 
     -- Tab manipulation commands
     { ":tab", "Execute command and open result in new tab.", {


### PR DESCRIPTION
This request checks if an argument is present when invoking `:js`. It will present a "nice" error to the user instead of calling eval_js() with an empty argument. This should help with issue https://github.com/luakit/luakit/issues/705