### PR TITLE
Fix tablist not hiding in fullscreen

### DIFF
--- a/lib/window.lua
+++ b/lib/window.lua
@@ -269,7 +269,7 @@ local init_funcs = {
     hide_ui_on_fullscreen = function (w)
         w.win:add_signal("property::fullscreen", function (win)
             w:update_sbar_visibility()
-            w.tablist.visible = not win.fullscreen
+            w.tablist.widget.visible = not win.fullscreen
         end)
     end,
 


### PR DESCRIPTION
It was bothering me for a long time that the tablist is visible when I open a YouTube video in fullscreen, so I finally fixed it with this in my `userconf.lua`:
```lua
window.add_signal('init', function(w)
    -- fix taglist not hiding when e.g. a youtube video is in fullscreen
    w.win:add_signal('property::fullscreen', function(win)
        w.tablist.widget.visible = not win.fullscreen
    end)
end)
```
But just after I dit that I've noticed the init function [hide_ui_on_fullscreen](https://github.com/luakit/luakit/blob/develop/lib/window.lua#L269) which does what I need except that it is most likely broken.
So here is a fix :)