### PR TITLE
Remove default shift-d bind for session deleting

### DIFF
--- a/lib/binds.lua
+++ b/lib/binds.lua
@@ -404,7 +404,6 @@ modes.add_binds("normal", {
     -- Window
     { "^ZZ$", "Quit and save the session.", function (w) w:save_session() w:close_win() end },
     { "^ZQ$", "Quit and don't save the session.", function (w) w:close_win() end },
-    { "^D$",  "Quit and don't save the session.", function (w) w:close_win() end },
 
     -- Enter passthrough mode
     { "<Control-z>", "Enter `passthrough` mode, ignores all luakit keybindings.",


### PR DESCRIPTION
It's an easy to mistype combination, so I think it should not have such a dangerous binding by default. `:q` and `ZQ` are enough already, some more complicated replacement like `ctrl-shift-q` may be added too.