### PR TITLE
command :save, to save the complete page as a single mhtml file

### DIFF
--- a/common/tokenize.list
+++ b/common/tokenize.list
@@ -109,6 +109,7 @@ remove
 reorder
 right
 sans_serif_font_family
+save
 screen
 scroll
 search

--- a/lib/binds.lua
+++ b/lib/binds.lua
@@ -12,6 +12,7 @@
 local _M = {}
 
 local window = require("window")
+local webview = require("webview")
 local taborder = require("taborder")
 local settings = require("settings")
 
@@ -566,6 +567,20 @@ end
                     w:notify("Dumped HTML to: " .. file)
                 end)
                 luakit.idle_add(function () coroutine.resume(co) end)
+            end
+        end },
+
+    { ":save", "Save page as shown to file,",
+        function (w, o)
+            local fname = string.gsub(w.win.title, '[^%w%.%-]', '_')..'.mhtml' -- sanitize filename
+            local file = o.arg or luakit.save_file("Save file", w.win, xdg.download_dir or '.', fname)
+            if file then
+                local view = w.view
+                view:add_signal("save-finished", function(v, file, err)
+                    local ww = webview.window(v)
+                    ww:notify(err or ("Saved to: " .. file))
+                end)
+                view:save(file)
             end
         end },
 })

--- a/luakit.1.in
+++ b/luakit.1.in
@@ -286,6 +286,9 @@ Open Download page, which displays all downloads along with their status.
 .B :dump
 Download current page.
 .TP
+.B :save
+Save the complete page as a single mhtml file.
+.TP
 .B :help
 Display all commands and bindings, along with their description. The help page
 also features some details about modes.


### PR DESCRIPTION
This is different than :dump in that it saves the whole page,not only its html.

I haven't found a simple way to display the result of the operation in the status bar. This is w:notify(...) in lua, but the webkit function for saving to file is asynchronous. Completion fires a callback (a c function) where the result of the operation can be retrieved. w:notify(...) should be called from there.