### PR TITLE
Improve performance of lousy.pickle

### DIFF
--- a/lib/lousy/pickle.lua
+++ b/lib/lousy/pickle.lua
@@ -22,19 +22,19 @@ function Pickle:pickle_(root)
     self._refToTable = {}
     local savecount = 0
     self:ref_(root)
-    local s = ""
+    local buf = {}
 
     while table.getn(self._refToTable) > savecount do
         savecount = savecount + 1
         local t = self._refToTable[savecount]
-        s = s.."{\n"
+        buf[#buf+1] = "{"
         for i, v in pairs(t) do
-                s = string.format("%s[%s]=%s,\n", s, self:value_(i), self:value_(v))
+                buf[#buf+1] = string.format("[%s]=%s,", self:value_(i), self:value_(v))
         end
-        s = s.."},\n"
+        buf[#buf+1] = "},"
     end
 
-    return string.format("{%s}", s)
+    return string.format("{%s\n}", table.concat(buf,"\n"))
 end
 
 function Pickle:value_(v)


### PR DESCRIPTION
The original implementation spawned a lot of intermediate concatenated strings, which is terrible in Lua: both for CPU usage, as a string needs to be copied into a new string, and for RAM usage, as old strings keep in memory regardless of their scope until GC destroys them.

With hundreds of tabs, this led to sudden RAM usage quakes during session saving. So, after trying to mitigate this with putting LuaKit in a cgroup, and with tuning the Lua GC to run more often (and to slow up the process even more), I have rewritten the serializer. Enjoy ;-)