### PR TITLE
Show WebView widgets only when switching to them

### DIFF
--- a/widgets/notebook.c
+++ b/widgets/notebook.c
@@ -127,6 +127,8 @@ luaH_notebook_switch(lua_State *L)
     gint i = luaL_checknumber(L, 2);
     /* correct index */
     if (i != -1) i--;
+    GtkWidget* page = gtk_notebook_get_nth_page(GTK_NOTEBOOK(w->widget), i);
+    gtk_widget_show(GTK_WIDGET(page));
     gtk_notebook_set_current_page(GTK_NOTEBOOK(w->widget), i);
     lua_pushnumber(L, gtk_notebook_get_current_page(GTK_NOTEBOOK(w->widget)));
     return 1;

--- a/widgets/notebook.c
+++ b/widgets/notebook.c
@@ -128,7 +128,7 @@ luaH_notebook_switch(lua_State *L)
     /* correct index */
     if (i != -1) i--;
     GtkWidget* page = gtk_notebook_get_nth_page(GTK_NOTEBOOK(w->widget), i);
-    gtk_widget_show(GTK_WIDGET(page));
+    gtk_widget_show(page);
     gtk_notebook_set_current_page(GTK_NOTEBOOK(w->widget), i);
     lua_pushnumber(L, gtk_notebook_get_current_page(GTK_NOTEBOOK(w->widget)));
     return 1;

--- a/widgets/webview.c
+++ b/widgets/webview.c
@@ -1437,9 +1437,6 @@ widget_webview(lua_State *L, widget_t *w, luakit_token_t UNUSED(token))
       "signal::open-window",                          G_CALLBACK(inspector_open_window_cb),     w,
       NULL);
 
-    /* show widgets */
-    //gtk_widget_show(GTK_WIDGET(d->view));
-
     return w;
 }
 

--- a/widgets/webview.c
+++ b/widgets/webview.c
@@ -1438,7 +1438,7 @@ widget_webview(lua_State *L, widget_t *w, luakit_token_t UNUSED(token))
       NULL);
 
     /* show widgets */
-    gtk_widget_show(GTK_WIDGET(d->view));
+    //gtk_widget_show(GTK_WIDGET(d->view));
 
     return w;
 }


### PR DESCRIPTION
This resolves the annoying https://github.com/luakit/luakit/issues/784 issue. As I suspected, a new WebView is spawned for **every** tab, even for those not loaded yet. Moreover, they are shown right after creation, which makes no sense for hidden widgets. This explains pretty well why all my plenty of non-loaded tabs were re-rendered behind the scenes and occupied tons of RAM for that.

After some more digging, I found the [possible reason](https://developer.gnome.org/gtk3/stable/GtkNotebook.html#gtk-notebook-set-current-page) for such behaviour:
> Note that due to historical reasons, GtkNotebook refuses to switch to a page unless the child widget is visible. Therefore, it is recommended to show child widgets before adding them to a notebook.

So, they should be shown already to be shown, huh. Though, nothing prevents it to be shown right before the switch, which my patch exactly does.

Now the browser performs well for me, but there may be some side effects.