### PR TITLE
Disable styling for source code

### DIFF
--- a/lib/styles.lua
+++ b/lib/styles.lua
@@ -228,7 +228,9 @@ end
 
 webview.add_signal("init", function (view)
     view:add_signal("stylesheet", function (v)
-        update_stylesheet_applications(v)
+        if not view.uri:match("view%-source") then
+            update_stylesheet_applications(v)
+        end
     end)
 end)
 


### PR DESCRIPTION
When using styles, `view-source:` pages get styled too, which is inconvenient. This disables that.

Next step is independent styling of `view-source:` pages. They already contain CSS, but the html code is not properly tagged so nothing happens.