### PR TITLE
Clear website data

### DIFF
--- a/clib/luakit.c
+++ b/clib/luakit.c
@@ -694,6 +694,15 @@ luaH_luakit_wch_upper(lua_State *L)
 }
 
 static gint
+luaH_luakit_clear_favicon_database(lua_State *UNUSED(L))
+{
+    WebKitWebContext *ctx = web_context_get();
+    WebKitFaviconDatabase *fdb = webkit_web_context_get_favicon_database(ctx);
+    webkit_favicon_database_clear(fdb);
+    return 0;
+}
+
+static gint
 luaH_luakit_push_install_paths_table(lua_State *L)
 {
     lua_createtable(L, 0, 6);
@@ -929,18 +938,19 @@ luakit_lib_setup(lua_State *L)
     {
         LUA_CLASS_METHODS(luakit)
         LUAKIT_LIB_COMMON_METHODS
-        { "__index",           luaH_luakit_index },
-        { "__newindex",        luaH_luakit_newindex },
-        { "exec",              luaH_luakit_exec },
-        { "quit",              luaH_luakit_quit },
-        { "save_file",         luaH_luakit_save_file },
-        { "spawn",             luaH_luakit_spawn },
-        { "spawn_sync",        luaH_luakit_spawn_sync },
-        { "register_scheme",   luaH_luakit_register_scheme },
-        { "allow_certificate", luaH_luakit_allow_certificate },
-        { "wch_lower",         luaH_luakit_wch_lower },
-        { "wch_upper",         luaH_luakit_wch_upper },
-        { NULL,              NULL }
+        { "__index",                luaH_luakit_index },
+        { "__newindex",             luaH_luakit_newindex },
+        { "exec",                   luaH_luakit_exec },
+        { "quit",                   luaH_luakit_quit },
+        { "save_file",              luaH_luakit_save_file },
+        { "spawn",                  luaH_luakit_spawn },
+        { "spawn_sync",             luaH_luakit_spawn_sync },
+        { "register_scheme",        luaH_luakit_register_scheme },
+        { "allow_certificate",      luaH_luakit_allow_certificate },
+        { "wch_lower",              luaH_luakit_wch_lower },
+        { "wch_upper",              luaH_luakit_wch_upper },
+        { "clear_favicon_database", luaH_luakit_clear_favicon_database },
+        { NULL,                     NULL }
     };
 
     /* create signals array */

--- a/clib/luakit.c
+++ b/clib/luakit.c
@@ -416,6 +416,12 @@ luaH_parse_website_data_types_table(lua_State *L, gint idx)
         TYPE(INDEXEDDB_DATABASES, indexeddb_databases)
         TYPE(PLUGIN_DATA, plugin_data)
         TYPE(COOKIES, cookies)
+#if WEBKIT_CHECK_VERSION(2,24,0)
+        TYPE(DEVICE_ID_HASH_SALT, device_id_hash_salt)
+#endif
+#if WEBKIT_CHECK_VERSION(2,26,0)
+        TYPE(HSTS_CACHE, hsts_cache)
+#endif
         TYPE(ALL, all)
 #undef TYPE
 
@@ -461,6 +467,12 @@ website_data_fetch_finish(WebKitWebsiteDataManager *manager, GAsyncResult *resul
             TYPE(INDEXEDDB_DATABASES, indexeddb_databases)
             TYPE(PLUGIN_DATA, plugin_data)
             TYPE(COOKIES, cookies)
+#if WEBKIT_CHECK_VERSION(2,24,0)
+            TYPE(DEVICE_ID_HASH_SALT, device_id_hash_salt)
+#endif
+#if WEBKIT_CHECK_VERSION(2,26,0)
+            TYPE(HSTS_CACHE, hsts_cache)
+#endif
 #undef TYPE
             lua_rawset(L, -3);
 

--- a/common/tokenize.list
+++ b/common/tokenize.list
@@ -9,6 +9,7 @@ can_go_back
 can_go_forward
 child
 children
+clear
 clear_search
 clipboard
 close_inspector

--- a/doc/luadoc/luakit.lua
+++ b/doc/luadoc/luakit.lua
@@ -228,4 +228,7 @@
 -- @readwrite
 -- @property resource_path
 
+--- Clear the favicon cache database.
+-- @function clear_favicon_database
+
 -- vim: et:sw=4:ts=8:sts=4:tw=80

--- a/lib/clear_data.lua
+++ b/lib/clear_data.lua
@@ -45,7 +45,7 @@ modes.new_mode("clear-data", {
                 table.insert(rows, {domain, list_data_types(website_data[domain])})
             end
             w.menu:build(rows)
-            w:notify("Use j/k to move, Return to clear all data, or c/d/i/l/m/o/p/s/w for a specific type.", false)
+            w:notify("Use j/k to move, Return to clear all data, or c/D/d/h/i/l/m/o/p/s/w for a specific type.", false)
         end)()
     end,
 
@@ -100,6 +100,8 @@ for _, args in ipairs({
     {"i", "indexeddb_databases"},
     {"p", "plugin_data"},
     {"c", "cookies"},
+    {"D", "device_id_hash_salt"},
+    {"h", "hsts_cache"},
 }) do
     add_clear_bind(unpack(args))
 end

--- a/lib/clear_data.lua
+++ b/lib/clear_data.lua
@@ -22,10 +22,11 @@ local function format_bytes(bytes)
     end
 end
 
+local data_type_binds = {}
 local function list_data_types(data)
     local s = ""
     for _, data_type in ipairs(lousy.util.table.keys(data)) do
-        s = s .. ", " .. data_type
+        s = s .. ", " .. data_type:gsub(data_type_binds[data_type], "<b>%0</b>", 1)
         if data[data_type] ~= 0 then
             s = s .. " (" .. format_bytes(data[data_type]) .. ")"
         end
@@ -45,7 +46,7 @@ modes.new_mode("clear-data", {
                 table.insert(rows, {domain, list_data_types(website_data[domain])})
             end
             w.menu:build(rows)
-            w:notify("Use j/k to move, Return to clear all data, or c/D/d/h/i/l/m/o/p/s/w for a specific type.", false)
+            w:notify("Use j/k to move, Return to clear all data, or c/d/e/h/i/l/m/o/p/s/w for a specific type.", false)
         end)()
     end,
 
@@ -55,6 +56,8 @@ modes.new_mode("clear-data", {
 })
 
 local function add_clear_bind(bind, data_type)
+    data_type_binds[data_type] = bind
+
     modes.add_binds("clear-data", {
         { bind, "Clear `"..data_type.."` for the focused domain.",
             function (w)
@@ -100,7 +103,7 @@ for _, args in ipairs({
     {"i", "indexeddb_databases"},
     {"p", "plugin_data"},
     {"c", "cookies"},
-    {"D", "device_id_hash_salt"},
+    {"e", "device_id_hash_salt"},
     {"h", "hsts_cache"},
 }) do
     add_clear_bind(unpack(args))

--- a/lib/clear_data.lua
+++ b/lib/clear_data.lua
@@ -113,6 +113,11 @@ modes.add_cmds({
         function (w)
             w:set_mode("clear-data")
         end },
+
+    { ":clear-favicon-db", "Clear the favicon cache database.",
+        function ()
+            luakit.clear_favicon_database()
+        end },
 })
 
 return _M

--- a/lib/clear_data.lua
+++ b/lib/clear_data.lua
@@ -1,0 +1,118 @@
+--- Clear website data.
+--
+-- This module provides an interface to clear website data, such as cache,
+-- cookies, local storage and databases.
+--
+-- @module clear_data
+-- @copyright 2019 Ulrik de Muelenaere <ulrikdem@gmail.com>
+
+local binds = require("binds")
+local lousy = require("lousy")
+local modes = require("modes")
+
+local _M = {}
+
+local function format_bytes(bytes)
+    if bytes < 1024 then
+        return string.format("%d B", bytes)
+    elseif bytes < 1024 * 1024 then
+        return string.format("%.1f KiB", bytes / 1024)
+    else
+        return string.format("%.1f MiB", bytes / (1024 * 1204))
+    end
+end
+
+local function list_data_types(data)
+    local s = ""
+    for _, data_type in ipairs(lousy.util.table.keys(data)) do
+        s = s .. ", " .. data_type
+        if data[data_type] ~= 0 then
+            s = s .. " (" .. format_bytes(data[data_type]) .. ")"
+        end
+    end
+    return s:sub(3)
+end
+
+modes.new_mode("clear-data", {
+    enter = function (w)
+        coroutine.wrap(function ()
+            local rows = {
+                {"Domain", "Data", title = true},
+                {"all", "all", clear_all = true},
+            }
+            local website_data = luakit.website_data.fetch({"all"})
+            for _, domain in ipairs(lousy.util.table.keys(website_data)) do
+                table.insert(rows, {domain, list_data_types(website_data[domain])})
+            end
+            w.menu:build(rows)
+            w:notify("Use j/k to move, Return to clear all data, or c/d/i/l/m/o/p/s/w for a specific type.", false)
+        end)()
+    end,
+
+    leave = function (w)
+        w.menu:hide()
+    end,
+})
+
+local function add_clear_bind(bind, data_type)
+    modes.add_binds("clear-data", {
+        { bind, "Clear `"..data_type.."` for the focused domain.",
+            function (w)
+                local focused_row = w.menu:get()
+                if not focused_row then
+                    return
+                end
+
+                coroutine.wrap(function()
+                    if focused_row.clear_all then
+                        luakit.website_data.clear({data_type})
+                    else
+                        luakit.website_data.remove({data_type}, focused_row[1])
+                    end
+
+                    local website_data = luakit.website_data.fetch({"all"})
+                    local i = 3 -- Skip title and "all" row
+                    while w.menu:get(i) do
+                        local row = w.menu:get(i)
+                        local domain = row[1]
+                        if website_data[domain] then
+                            row[2] = list_data_types(website_data[domain])
+                            i = i + 1
+                        else
+                            w.menu:del(i)
+                        end
+                    end
+                    w.menu:update()
+                end)()
+            end },
+    })
+end
+
+add_clear_bind("<Return>", "all")
+
+for _, args in ipairs({
+    {"m", "memory_cache"},
+    {"d", "disk_cache"},
+    {"o", "offline_application_cache"},
+    {"s", "session_storage"},
+    {"l", "local_storage"},
+    {"w", "websql_databases"},
+    {"i", "indexeddb_databases"},
+    {"p", "plugin_data"},
+    {"c", "cookies"},
+}) do
+    add_clear_bind(unpack(args))
+end
+
+modes.add_binds("clear-data", binds.menu_binds)
+
+modes.add_cmds({
+    { ":clear-data", "Open menu to clear website data.",
+        function (w)
+            w:set_mode("clear-data")
+        end },
+})
+
+return _M
+
+-- vim: et:sw=4:ts=8:sts=4:tw=80


### PR DESCRIPTION
This PR adds the `clear_data` module, which provides 2 commands:
* `:clear-data` opens a menu showing the information from the `luakit.website_data` API, and allows clearing the data of {all types,a specific type} for {all domains,a specific domain}.
* `:clear-favicon-db` clears the favicon cache database.

This is supported by 2 new functions in the `luakit` module:
* `luakit.website_data.clear()`, which wraps `webkit_website_data_manager_clear()`.
* `luakit.clear_favicon_database()`, which wraps `webkit_favicon_database_clear()`.