### PR TITLE
Correct @-moz-document parsing; resolves issue #665.

### DIFF
--- a/lib/styles.lua
+++ b/lib/styles.lua
@@ -245,7 +245,7 @@ local parse_moz_document_subrule = function (file)
 end
 
 local parse_moz_document_section = function (file, parts)
-    file = file:gsub("^%s*%@%-moz%-document%f[^%w]", "")
+    file = file:gsub("^%s*%@%-moz%-document%f[%W]", "")
     local when = {}
     local word, param
 

--- a/lib/styles.lua
+++ b/lib/styles.lua
@@ -236,7 +236,7 @@ end)
 
 local parse_moz_document_subrule = function (file)
     local word, param, i
-    word, i = file:match("^%s+([%w-]+)%s*()")
+    word, i = file:match("^%s*([%w-]+)%s*()")
     file = file:sub(i)
     param, i = file:match("(%b())()")
     file = file:sub(i)
@@ -245,7 +245,7 @@ local parse_moz_document_subrule = function (file)
 end
 
 local parse_moz_document_section = function (file, parts)
-    file = file:gsub("^%s*%@%-moz%-document", "")
+    file = file:gsub("^%s*%@%-moz%-document%f[^%s]", "")
     local when = {}
     local word, param
 

--- a/lib/styles.lua
+++ b/lib/styles.lua
@@ -245,7 +245,7 @@ local parse_moz_document_subrule = function (file)
 end
 
 local parse_moz_document_section = function (file, parts)
-    file = file:gsub("^%s*%@%-moz%-document%f[^%s]", "")
+    file = file:gsub("^%s*%@%-moz%-document%f[^%w]", "")
     local when = {}
     local word, param
 


### PR DESCRIPTION
This corrects #665. The original fix by @Caagr98, and an extra end-of-token check when parsing '@-moz-document' to ensure it's well-formedness. 