### PR TITLE
window/new_tab: reload view/tab when openning new view/tab

### DIFF
--- a/lib/window.lua
+++ b/lib/window.lua
@@ -472,7 +472,7 @@ _M.methods = {
             w:search_open_navigate(view, arg)
         end
 
-        w:reload()
+        view:reload()
         return view
     end,
 


### PR DESCRIPTION
This change reloads views/tabs when they are opened, and prevents the
current tab from being refreshed when a link is followed in a new tab.

This corrects the intended behavior of 280813b1b3, and fixes #828.