### PR TITLE
Honor window.new_tab_page for cases where tab is opened without uri set

### DIFF
--- a/lib/session.lua
+++ b/lib/session.lua
@@ -128,10 +128,10 @@ local restore_file = function (file, delete)
         for _, item in ipairs(win.open) do
             local v
             if not w then
-                w = window.new({"about:blank"})
+                w = window.new({settings.get_setting("window.new_tab_page")})
                 v = w.view
             else
-                v = w:new_tab("about:blank", { switch = item.current })
+                v = w:new_tab(settings.get_setting("window.new_tab_page"), { switch = item.current })
             end
             -- Block the tab load, then set its location
             webview.modify_load_block(v, "session-restore", true)

--- a/lib/window.lua
+++ b/lib/window.lua
@@ -463,6 +463,9 @@ _M.methods = {
         if not view then
             -- Make new webview widget
             view = webview.new({ private = opts.private })
+            if not arg then
+                view.uri = settings.get_setting("window.new_tab_page")
+            end
             w:attach_tab(view, switch, order)
         end
 


### PR DESCRIPTION
This sets the tab uri to window.new_tab_page when there is no uri passed
to new_tab (e.g. when calling :open or :tabopen without any parameters).
It also uses new_tab_page when restoring sessions with empty tabs.

Fixes #752