### PR TITLE
Fix GLib log messages

### DIFF
--- a/log.c
+++ b/log.c
@@ -90,13 +90,13 @@ log_group_from_fct(const char *fct)
     int len = strlen(fct);
     gboolean core = !strcmp(&fct[len-2], ".c") || !strcmp(&fct[len-2], ".h"),
              lua = !strcmp(&fct[len-4], ".lua") || !strncmp(fct, "[string \"", 9);
-    if (core == lua)
-        warn("not sure how to handle this one: '%s'", fct);
 
     if (core) /* Strip .c or .lua off the end */
         return g_strdup_printf("core/%.*s", len-2, fct);
-    else
+    else if (lua)
         return g_strdup_printf("lua/%.*s", len-4, fct);
+    else
+        return g_strdup(fct);
 }
 
 int

--- a/luakit.c
+++ b/luakit.c
@@ -163,15 +163,11 @@ static GLogWriterOutput
 glib_log_writer(GLogLevelFlags log_level_flags, const GLogField *fields, gsize n_fields, gpointer UNUSED(user_data))
 {
     const gchar *log_domain = "(unknown)",
-                *message = "(empty)",
-                *code_file = "(unknown)",
-                *code_line = "(unknown)";
+                *message = "(empty)";
 
     for (gsize i = 0; i < n_fields; ++i) {
         if (!strcmp(fields[i].key, "GLIB_DOMAIN")) log_domain = fields[i].value;
         if (!strcmp(fields[i].key, "MESSAGE")) message = fields[i].value;
-        if (!strcmp(fields[i].key, "CODE_FILE")) code_file = fields[i].value;
-        if (!strcmp(fields[i].key, "CODE_LINE")) code_line = fields[i].value;
     }
 
     /* Probably not necessary, but just in case... */
@@ -187,7 +183,7 @@ glib_log_writer(GLogLevelFlags log_level_flags, const GLogField *fields, gsize n
         [G_LOG_LEVEL_DEBUG]    = LOG_LEVEL_debug,
     })[log_level_flags];
 
-    _log(log_level, code_line, code_file, "%s: %s", log_domain, message);
+    _log(log_level, "glib", "%s: %s", log_domain, message);
     return G_LOG_WRITER_HANDLED;
 }
 #endif


### PR DESCRIPTION
For GLib log messages, the wrong number of arguments were passed to `_log()`, resulting in the actual message not being logged. Additionally, since it did not pass in a filename that looked like a luakit module, `log_group_from_fct()` would often log a warning.

Since the filename and line number are often not available, and may not be as useful for log messages from an external library, I have removed them from the log, using "glib" as the log group. If this information is desired, I would suggest adding it to the log message (rather than the group) when available.