### PR TITLE
Avoid setting web process limit on WebKit 2.26

### DIFF
--- a/config/rc.lua
+++ b/config/rc.lua
@@ -24,7 +24,8 @@ end)
 
 require "unique_instance"
 
--- Set the number of web processes to use. A value of 0 means 'no limit'.
+-- Set the number of web processes to use. A value of 0 means 'no limit'. This
+-- has no effect since WebKit 2.26
 luakit.process_limit = 4
 -- Set the cookie storage location
 soup.cookies_storage = luakit.data_dir .. "/cookies.db"

--- a/web_context.c
+++ b/web_context.c
@@ -125,9 +125,11 @@ web_context_init_finish(void)
     if (web_context_started)
         return;
 
+#if !WEBKIT_CHECK_VERSION(2,26,0)
     webkit_web_context_set_process_model(web_context, WEBKIT_PROCESS_MODEL_MULTIPLE_SECONDARY_PROCESSES);
     info("Web process count: %d", process_limit);
     webkit_web_context_set_web_process_count_limit(web_context, process_limit);
+#endif
 
     web_context_started = TRUE;
 }


### PR DESCRIPTION
This is deprecated since WebKitGTK 2.26 and no longer has any effect.