### PR TITLE
gcc 10 build fix.

### DIFF
--- a/clib/widget.h
+++ b/clib/widget.h
@@ -87,7 +87,7 @@ struct widget_t
     gpointer data;
 };
 
-lua_class_t widget_class;
+extern lua_class_t widget_class;
 void widget_class_setup(lua_State *);
 void widget_set_css_properties(widget_t *, ...);
 gint luaH_widget_new(lua_State *L);

--- a/common/common.h
+++ b/common/common.h
@@ -26,7 +26,7 @@ typedef struct _common_t {
     lua_State *L;
 } common_t;
 
-common_t common;
+extern common_t common;
 
 #endif
 

--- a/extension/extension.c
+++ b/extension/extension.c
@@ -49,6 +49,9 @@ everywhere in extensions; note that this common is separate
 from the common visible on the UI side. */
 common_t common;
 
+/* Similarly, this is the global definition of extension */
+extension_t extension;
+
 
 static void
 web_lua_init(const char *package_path, const char *package_cpath)

--- a/extension/extension.c
+++ b/extension/extension.c
@@ -43,6 +43,13 @@
 #include "extension/luajs.h"
 #include "extension/script_world.h"
 
+/* This is the global definition of common; it's also visible
+everwhere common/common.h is included, which probably is about
+everywhere in extensions; note that this common is separate
+from the common visible on the UI side. */
+common_t common;
+
+
 static void
 web_lua_init(const char *package_path, const char *package_cpath)
 {

--- a/extension/extension.h
+++ b/extension/extension.h
@@ -41,7 +41,7 @@ typedef struct _extension_t {
     WebKitScriptWorld *script_world;
 } extension_t;
 
-extension_t extension;
+extern extension_t extension;
 
 #endif
 

--- a/globalconf.h
+++ b/globalconf.h
@@ -68,7 +68,7 @@ typedef struct {
     gdouble starttime;
 } globalconf_t;
 
-globalconf_t globalconf;
+extern globalconf_t globalconf;
 
 #endif
 

--- a/luakit.c
+++ b/luakit.c
@@ -38,9 +38,10 @@
 #error Your version of WebKit is outdated!
 #endif
 
-/* Define the three globals; their extern declarations are in
-common/common.h, globalconf.h, and clib/widget.h; they can only be
-defined non-extern in one module starting with gcc 10. */
+/* Define two globals of the UI side; their extern declarations are in
+globalconf.h, and clib/widget.h, and so they're visible pretty much
+everywhere; there's also common for lua communication; there's a second
+definition of that in extension/extension (which is a separate process). */
 common_t common;
 globalconf_t globalconf;
 lua_class_t widget_class;

--- a/luakit.c
+++ b/luakit.c
@@ -38,6 +38,13 @@
 #error Your version of WebKit is outdated!
 #endif
 
+/* Define the three globals; their extern declarations are in
+common/common.h, globalconf.h, and clib/widget.h; they can only be
+defined non-extern in one module starting with gcc 10. */
+common_t common;
+globalconf_t globalconf;
+lua_class_t widget_class;
+
 static void
 init_directories(void)
 {


### PR DESCRIPTION
This declares the three cross-module globals as extern in the headers
so the headers can safely be included in multiple modules.

The actual definitions are in luakit.c.

This would hopefully fix Debian bug https://bugs.debian.org/957511