### PR TITLE
Fix re_match_text matching everything everytime

### DIFF
--- a/lib/follow.lua
+++ b/lib/follow.lua
@@ -160,7 +160,7 @@ local function regex_escape(s)
     return s:gsub(escape_pat, "%%%1")
 end
 
-local re_match_text = function (text) return "", text end
+local re_match_text = function (text) return nil, text end
 local re_match_both = function (text) return text, text end
 local match_label_re_text = function (text)
     return #text > 0 and "^"..regex_escape(text) or "", text


### PR DESCRIPTION
Returing an empty string for the `hint` makes it so EVERY hint is
matched (since "" is a substring of every string). Returing `nil` (like
in `match_label`) fixes it. Fixes #841 