### PR TITLE
Avoid a panic if there's problems reading /etc/hosts

### DIFF
--- a/lib/lousy/uri.lua
+++ b/lib/lousy/uri.lua
@@ -70,7 +70,8 @@ function _M.is_uri(s)
     -- Valid hostnames to check
     local hosts = {"localhost"}
     if get_setting("window.load_etc_hosts") then
-        hosts = util.get_etc_hosts()
+        ok, hosts = pcall(util.get_etc_hosts)
+        if not ok then hosts = {} end
     end
     -- Check hostnames
     for _, h in pairs(hosts) do

--- a/lib/lousy/uri.lua
+++ b/lib/lousy/uri.lua
@@ -68,10 +68,12 @@ function _M.is_uri(s)
     end
 
     -- Valid hostnames to check
-    local hosts = {"localhost"}
+    local ok, hosts
     if get_setting("window.load_etc_hosts") then
         ok, hosts = pcall(util.get_etc_hosts)
         if not ok then hosts = {} end
+    else
+        hosts = {"localhost"}
     end
     -- Check hostnames
     for _, h in pairs(hosts) do


### PR DESCRIPTION
In case that, for whatever reason, the file /etc/hosts is missing
from the system or it otherwise can't be read an unprotected call
to io.lines() raises an error which bubbles up to panic the host.

This seems undesireable, certainly a full panic is not wanted.

Here we look the other way and pretend the hosts file was just empty.