### PR TITLE
When a policy decision is requested, accept a (formal) status of 0 as…

### DIFF
--- a/widgets/webview.c
+++ b/widgets/webview.c
@@ -526,7 +526,8 @@ decide_policy_cb(WebKitWebView* UNUSED(v), WebKitPolicyDecision *p,
         const gchar *uri = webkit_uri_response_get_uri(r);
         const gchar *mime = webkit_uri_response_get_mime_type(r);
 
-        if(!SOUP_STATUS_IS_SUCCESSFUL(webkit_uri_response_get_status_code(r)))
+        if(webkit_uri_response_get_status_code(r)
+            && !SOUP_STATUS_IS_SUCCESSFUL(webkit_uri_response_get_status_code(r)))
             return FALSE;
 
         luaH_object_push(L, w->ref);


### PR DESCRIPTION
… success.

Background: webkit_uri_response_get_status_code(r) apparently returns 0
for local resources.  SOUP_STATUS_IS_SUCCESSFUL then is false, and a
fixed "no" policy is returned, leading to bug #742.

This fixes #742 for me, and it doesn't seem to affect anything else
adversely, though of course I can't really say if there are other conditions
when there is a 0 in response->status_code=0.