### PR TITLE
Don't destroy last view if close_with_last_tab=false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fixed bounding box not spanning over whole element.
 - Fixed an issue where styled hint labels caused intransparent bounding boxes.
+- Fixed a race condition when a tab is closed on NetBSD.
 
 ## [2.2]
 

--- a/common/ipc.c
+++ b/common/ipc.c
@@ -21,6 +21,7 @@
 #include "common/lualib.h"
 #include "common/luaserialize.h"
 #include "common/ipc.h"
+#include "log.h"
 
 /* Prototypes for ipc_recv_... functions */
 #define X(name) void ipc_recv_##name(ipc_endpoint_t *ipc, const void *msg, guint length);
@@ -138,6 +139,18 @@ ipc_recv_and_dispatch_or_enqueue(ipc_endpoint_t *ipc)
         case G_IO_STATUS_AGAIN:
             return;
         case G_IO_STATUS_EOF:
+            verbose("g_io_channel_read_chars(): End Of File received");
+            /* OSX and NetBSD are sending EOF on nonblocking channels first.
+             * This EOF can be ignored. They should end up in recv_hup(),
+             * but unfortunaltey they do not.
+             *
+             * In order to avoid an incref/decref loop. The refcount is
+             * forced down here until it reaches 1. Once 1 is reached,
+             * the decref call after this function will bring it to 0 and
+             * clean up the channel.
+             */
+            if(&ipc->refcount > 1)
+                g_atomic_int_dec_and_test(&ipc->refcount);
             return;
         case G_IO_STATUS_ERROR:
             if (!g_str_equal(ipc->name, "UI"))


### PR DESCRIPTION
This is yet another attempt to fix https://github.com/luakit/luakit/issues/725. The problem here is that `w.tab:count()` is  1 when closing the second tab (1 left) but also on the last tab, because detach-tab does also detect this situation and does not detach it (so tabcount stays 1).

My version here properly detect this situation by saving the tab count before detach_tab is called and prevents to destroy the webview in this case.

As I don't have the issue on my machine, I'd like to ask @iamleot to retest.