### PR TITLE
No git check without .git directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed bounding box not spanning over whole element.
 - Fixed an issue where styled hint labels caused intransparent bounding boxes.
 - Fixed a race condition when a tab is closed on NetBSD.
+- Do not execute "git ls-files" when luakit is not a git repository
 
 ## [2.2]
 

--- a/tests/run_test.lua
+++ b/tests/run_test.lua
@@ -187,20 +187,24 @@ if not pcall(require, "luassert") then
 end
 
 -- Check for untracked files in Git
-do
-    local untracked = {}
-    local f = io.popen("git ls-files --others --exclude-standard")
-    for line in f:lines() do
-        table.insert(untracked, line)
-    end
-    f:close()
+local git=io.open(".git","r")
+if git~=nil then
+    io.close(git)
+    do
+        local untracked = {}
+        local f = io.popen("git ls-files --others --exclude-standard")
+        for line in f:lines() do
+            table.insert(untracked, line)
+        end
+        f:close()
 
-    if #untracked > 0 then
-        local c_yellow = string.char(27) .. "[0;33m"
-        local c_reset = string.char(27) .. "[0;0m"
-        print(c_yellow .. "WARN" .. c_reset .. " The following files are untracked:")
-        for _, line in ipairs(untracked) do
-            print("  " .. line)
+        if #untracked > 0 then
+            local c_yellow = string.char(27) .. "[0;33m"
+            local c_reset = string.char(27) .. "[0;0m"
+            print(c_yellow .. "WARN" .. c_reset .. " The following files are untracked:")
+            for _, line in ipairs(untracked) do
+                print("  " .. line)
+            end
         end
     end
 end


### PR DESCRIPTION
When luakit is built, `git ls-files` is called.

When luakit itself is not a git repository, but part of a bigger repository (for example as part of a ports tree which is fetched via git) then a huge list of unrelated files is printed.

This change looks for a ".git" directory first and carries out the `git ls-files` check only when one is found.