### PR TITLE
[WIP] Save last active proxy (even if it's none)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - Removed debug symbol generation for default make.
 - Changed the C standard from gnu99 to c11 because Webkit wants it.
+- The proxy module saves when no proxy or system proxy was used last.
+- The proxy widget is hidden when proxy "None" is active.
 
 ### Fixed
 

--- a/lib/proxy.lua
+++ b/lib/proxy.lua
@@ -54,7 +54,7 @@ local active = noproxy
 local update_proxy_indicator = function (w)
     local name = _M.get_active().name
     local proxyi = w.sbar.r.proxyi
-    if name then
+    if name and name ~= "None" then
         local text = string.format("[%s]", name)
         if proxyi.text ~= text then proxyi.text = text end
         proxyi:show()

--- a/lib/proxy.lua
+++ b/lib/proxy.lua
@@ -181,19 +181,14 @@ window.add_signal("init", function (w)
     r.proxyi.font = theme.proxyi_sbar_font
     update_proxy_indicators()
 
-    -- on first load, place default proxies in proxy file
-    local fd = io.open(proxies_file, "r")
-    if fd~=nil then
-        io.close(fd)
-    else
-        proxies["None"] = "no_proxy"
-        proxies["System"] = "default"
-    end
+    -- always add default entries
+    proxies["None"]   = "no_proxy"
+    proxies["System"] = "default"
 end)
 
 new_mode("proxymenu", {
     enter = function (w)
-        local rows = {{ "Proxy Name", " Server address", title = true },}
+        local rows = {{ "Proxy Name", " Server address", title = true }}
         for _, name in ipairs(_M.get_names()) do
             local address = _M.get(name)
             table.insert(rows, {

--- a/lib/proxy.lua
+++ b/lib/proxy.lua
@@ -111,6 +111,10 @@ function _M.load(fd_name)
         soup.proxy_uri = active.address
         update_proxy_indicators()
     end
+
+    -- always add default entries
+    proxies["None"]   = "no_proxy"
+    proxies["System"] = "default"
 end
 
 --- Save the proxies list to a file.
@@ -180,10 +184,6 @@ window.add_signal("init", function (w)
     r.proxyi.fg = theme.proxyi_sbar_fg
     r.proxyi.font = theme.proxyi_sbar_font
     update_proxy_indicators()
-
-    -- always add default entries
-    proxies["None"]   = "no_proxy"
-    proxies["System"] = "default"
 end)
 
 new_mode("proxymenu", {

--- a/lib/proxy.lua
+++ b/lib/proxy.lua
@@ -180,13 +180,20 @@ window.add_signal("init", function (w)
     r.proxyi.fg = theme.proxyi_sbar_fg
     r.proxyi.font = theme.proxyi_sbar_font
     update_proxy_indicators()
+
+    -- on first load, place default proxies in proxy file
+    local fd = io.open(proxies_file, "r")
+    if fd~=nil then
+        io.close(fd)
+    else
+        proxies["None"] = "no_proxy"
+        proxies["System"] = "default"
+    end
 end)
 
 new_mode("proxymenu", {
     enter = function (w)
-        local rows = {{ "Proxy Name", " Server address", title = true },
-            {"  None",   "", address = "no_proxy", },
-            {"  System", "", address = "default",  },}
+        local rows = {{ "Proxy Name", " Server address", title = true },}
         for _, name in ipairs(_M.get_names()) do
             local address = _M.get(name)
             table.insert(rows, {


### PR DESCRIPTION
I was fiddling around with the proxymenu, so it persists the last use proxy, even when it is "None" or "System".

This seems to work, but only when the passmenu file is being deleted and recreated. This is not nice, but it's a start... 

This relates to https://github.com/luakit/luakit/issues/879