### PR TITLE
Fix default for tablist.visibility settings

### DIFF
--- a/lib/lousy/widget/tablist.lua
+++ b/lib/lousy/widget/tablist.lua
@@ -266,7 +266,7 @@ settings.register_settings({
             ["multiple"] = { desc = "Hide tab list if there's only one tab.", label = "If multiple tabs", },
             ["never"] = { desc = "Never display tab list.", label = "Never", },
         },
-        default = false,
+        default = "multiple",
         domain_specific = false,
         desc = "When should the tab list be visible?",
     },


### PR DESCRIPTION
The default is not selected (none in fact) on the luakit://settings page the patch fix this, cheers