### PR TITLE
Remove compile warnings

### DIFF
--- a/common/util.h
+++ b/common/util.h
@@ -47,11 +47,12 @@
 #define WARN_UNUSED __attribute__ ((warn_unused_result))
 
 /* stack pushing macros */
-#define PB_CASE(t, b) case L_TK_##t: lua_pushboolean   (L, b); return 1;
-#define PF_CASE(t, f) case L_TK_##t: lua_pushcfunction (L, f); return 1;
-#define PI_CASE(t, i) case L_TK_##t: lua_pushinteger   (L, i); return 1;
-#define PN_CASE(t, n) case L_TK_##t: lua_pushnumber    (L, n); return 1;
-#define PS_CASE(t, s) case L_TK_##t: lua_pushstring    (L, s); return 1;
+#define PB_CASE(t, b) case L_TK_##t: lua_pushboolean       (L, b); return 1;
+#define PF_CASE(t, f) case L_TK_##t: lua_pushcfunction     (L, f); return 1;
+#define PI_CASE(t, i) case L_TK_##t: lua_pushinteger       (L, i); return 1;
+#define PN_CASE(t, n) case L_TK_##t: lua_pushnumber        (L, n); return 1;
+#define PS_CASE(t, s) case L_TK_##t: lua_pushstring        (L, s); return 1;
+#define PD_CASE(t, d) case L_TK_##t: lua_pushlightuserdata (L, d); return 1;
 
 /* A NULL resistant strlen. Unlike it's libc sibling, l_strlen returns a
  * ssize_t, and supports its argument being NULL. */

--- a/widgets/common.c
+++ b/widgets/common.c
@@ -379,8 +379,12 @@ luaH_widget_send_key(lua_State *L)
 
     GdkKeymapKey *keys = NULL;
     gint n_keys;
-    if (!gdk_keymap_get_entries_for_keyval(gdk_keymap_get_default(),
-                                           keyval, &keys, &n_keys)) {
+#if GTK_CHECK_VERSION(3,22,0)
+    GdkKeymap *keymap = gdk_keymap_get_for_display(gdk_display_get_default());
+#else
+    GdkKeymap *keymap = gdk_keymap_get_default();
+#endif
+    if (!gdk_keymap_get_entries_for_keyval(keymap, keyval, &keys, &n_keys)) {
         g_string_free(state_string, TRUE);
         return luaL_error(L, "cannot type '%s' on current keyboard layout",
                           key_name);

--- a/widgets/window.c
+++ b/widgets/window.c
@@ -112,7 +112,7 @@ luaH_window_index(lua_State *L, widget_t *w, luakit_token_t token)
 
 # ifdef GDK_WINDOWING_X11
       case L_TK_ROOT_WIN_XID:
-        lua_pushinteger(L, GDK_WINDOW(
+        lua_pushlightuserdata(L, GDK_WINDOW(
 #  if GTK_CHECK_VERSION(3,12,0)
                 gdk_screen_get_root_window(gtk_widget_get_screen(GTK_WIDGET(d->win)))
 #  else
@@ -121,7 +121,7 @@ luaH_window_index(lua_State *L, widget_t *w, luakit_token_t token)
         ));
         return 1;
 
-      PI_CASE(WIN_XID, GDK_WINDOW(gtk_widget_get_window(GTK_WIDGET(d->win))));
+      PD_CASE(WIN_XID, GDK_WINDOW(gtk_widget_get_window(GTK_WIDGET(d->win))));
 # endif
 
       case L_TK_SCREEN:


### PR DESCRIPTION
This corrects some compile time warnings that i'm seeing. It:
- Removes a deprecation warning about `gdk_keymap_get_default()`
- Changes a `lua_pushinteger` call to `lua_pushlightuserdata` to remove an "integer from pointer" complaint.
- Defines a `PD_CASE` macro (by analogy with PI_CASE) and replaces a PI_CASE call to remove an "integer from pointer" complaint.

Although these changes _feel_ right to me and the browser still seems to function,
i don't grok the C-LUA interface well enough to trust my judgement,
and i've not gone to the effort of making sure that those lines have been executed in my testing.