### PR TITLE
Correct/remove centre-finding behaviour in `click` evaluator (closes #916)

### DIFF
--- a/lib/follow_wm.lua
+++ b/lib/follow_wm.lua
@@ -30,7 +30,10 @@ local evaluators = {
         if element.child_count > 0 then
             local r = element.rect
             local doc = element.owner_document
-            element = doc:element_from_point(r.left + r.width/2, r.top + r.height/2) or element
+            local scroll = page:eval_js([=[ window.scrollX + ' ' + window.scrollY; ]=])
+            local scrollX, scrollY = scroll:match("^(%S+) (%S+)$")
+            element = doc:element_from_point(r.left - scrollX + r.width/2,
+                                             r.top - scrollY + r.height/2)
         end
         element:click()
     end,


### PR DESCRIPTION
So the discussion about how to best close #916 rather petered out.

This PR intentionally has two separate commits to more easily facilitate the removal of the more drastic (second) change.
The first (6c09e81b) subtracts the viewport from the `element.rect`, correcting the current behaviour.
The second (2045a50) deletes this clause entirely, so the hinted element is clicked, rather than it's central child.
My belief (#916 for rationale) is that this clause is unnecessary,
but there _may_ be valid reasons for it being there which i've not considered,
in which case reverting 2045a50 will still leave the situation corrected.