### PR TITLE
Generalise keysym

### DIFF
--- a/lib/keysym.lua
+++ b/lib/keysym.lua
@@ -18,9 +18,9 @@
 
 local _M = {}
 
---- Send synthetic keys to given window.
+--- Send synthetic keys to given widget.
 -- This function parses a vim-like keystring into single keys and sends
--- them to the window. A keystring is a string of keys to press, with
+-- them to the widget. A keystring is a string of keys to press, with
 -- special keys denoted in between angle brackets:
 --
 --     keysym.send(w, "<Shift-Home><BackSpace>")
@@ -29,12 +29,21 @@ local _M = {}
 -- Sending special unicode characters needs related keyboard layout to be set.
 --     keysym.send(w, "Приветствую, мир")
 --
--- When `window.act_on_synthetic_keys` is disabled, synthetic key events will
--- not trigger other key bindings.
--- @tparam w The window object.
+-- When `window.act_on_synthetic_keys` is disabled, synthetic key events sent to
+-- a window widget will not trigger other key bindings.
+-- @tparam w The widget to send keys to.
 -- @tparam string keystring The key string representing synthetic keys.
 _M.send = function (w, keystring)
-    assert(type(w) == "table", "table expected, found "..type(w))
+    assert(w)
+
+    -- _M.send previously took a window object/table, and sent keys to w.win.
+    -- It can now take any widget, and send keys to that.
+    -- If w is a table, assume that the old interface is desired,
+    -- and re-assign w to w.win to retain backwards compatibility.
+    if type(w) == "table" then
+        w = w.win
+    end
+
     assert(type(keystring) == "string", "string expected, found "..type(keystring))
     local symbol = nil
     local modifiers = {}
@@ -76,7 +85,7 @@ _M.send = function (w, keystring)
     end
     if symbol then error("unterminated symbol: " .. symbol) end
     for _, key in ipairs(keys) do
-        w.win:send_key(key.key, key.mods)
+        w:send_key(key.key, key.mods)
     end
 end
 


### PR DESCRIPTION
Luakit's key binding infrastructure has the window intercepting and interpreting all key strokes,
unless the user has entered `passthrough` or `insert` modes.
Some websites provide users with keyboard shortcuts to facilitate more efficient use of their UI.
An example of this is github providing `gi` and `gp` to go to Issues and Pull Request pages respectively.
Currently in Luakit, jumping in and out of `passthrough` is required to access shortcuts like these.
A mechanism to allow luakit to recognise key bindings and send keys on to the webview would streamline this.


Currently synthetic single-keys can be sent to widgets using `widget.send_key()` (aka `luaH_widget_send_key`).
To allow more sophisticated strings to be sent to the window, the `keysym` module was authored.
`keysym` iterates over a supplied string, and sends each character in turn to the window's widget (via `send_key`).

This PR generalises `keysym`'s behaviour so that it can accept (and send keys to) any widget,
making it trivial to (for example) pass multi-key strings through to the webview, 
allowing for keybindings along the lines of:
```
local keysym = require("keysym")
modes.add_cmds({
    { ":pr",       "Open Pull Requests on github",         function (w, a) keysym.send(w.view, "gp") end },
})
```

The examples provided here are somewhat contrived, and this PR won't drastically improve the efficiency in these cases.
However, the change is small, and unless there is a good reason for restricting the action of `keysym`,
i feel that making it's function more general is an improvement.