### PR TITLE
Updated Makefile so LIBDIR actually does something

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,8 @@ install: all
 	install -m644 lib/*.* $(DESTDIR)$(PREFIX)/share/luakit/lib
 	install -m644 lib/lousy/*.* $(DESTDIR)$(PREFIX)/share/luakit/lib/lousy
 	install -m644 lib/lousy/widget/*.* $(DESTDIR)$(PREFIX)/share/luakit/lib/lousy/widget
-	install -d $(DESTDIR)$(LIBDIR)/luakit
-	install -m644 luakit.so $(DESTDIR)$(LIBDIR)/luakit/luakit.so
+	install -d $(DESTDIR)$(LIBDIR)
+	install -m644 luakit.so $(DESTDIR)$(LIBDIR)/luakit.so
 	install -d $(DESTDIR)$(PREFIX)/bin
 	install luakit $(DESTDIR)$(PREFIX)/bin/luakit
 	install -d $(DESTDIR)$(XDGPREFIX)/luakit/

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ options:
 	@echo "XDGPREFIX    = $(XDGPREFIX)"
 	@echo "PIXMAPDIR    = $(PIXMAPDIR)"
 	@echo "APPDIR       = $(APPDIR)"
-	@echo "APPDIR       = $(LIBDIR)"
+	@echo "LIBDIR       = $(LIBDIR)"
 	@echo
 	@echo build targets:
 	@echo "SRCS     = $(SRCS)"

--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,8 @@ install: all
 	install -m644 lib/*.* $(DESTDIR)$(PREFIX)/share/luakit/lib
 	install -m644 lib/lousy/*.* $(DESTDIR)$(PREFIX)/share/luakit/lib/lousy
 	install -m644 lib/lousy/widget/*.* $(DESTDIR)$(PREFIX)/share/luakit/lib/lousy/widget
-	install -d $(DESTDIR)$(PREFIX)/lib/luakit
-	install -m644 luakit.so $(DESTDIR)$(PREFIX)/lib/luakit/luakit.so
+	install -d $(DESTDIR)$(LIBDIR)/luakit
+	install -m644 luakit.so $(DESTDIR)$(LIBDIR)/luakit/luakit.so
 	install -d $(DESTDIR)$(PREFIX)/bin
 	install luakit $(DESTDIR)$(PREFIX)/bin/luakit
 	install -d $(DESTDIR)$(XDGPREFIX)/luakit/

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ options:
 	@echo "XDGPREFIX    = $(XDGPREFIX)"
 	@echo "PIXMAPDIR    = $(PIXMAPDIR)"
 	@echo "APPDIR       = $(APPDIR)"
+	@echo "APPDIR       = $(LIBDIR)"
 	@echo
 	@echo build targets:
 	@echo "SRCS     = $(SRCS)"


### PR DESCRIPTION
While packaging luakit for opensuse, I found it was a struggle to get the library to it's proper location (lib64) and after investigating, found that the LIBDIR variable is unused. So I went and fixed it so LIBDIR can actually do something.