### PR TITLE
Substitute full commit hash in getversion.sh

### DIFF
--- a/build-utils/getversion.sh
+++ b/build-utils/getversion.sh
@@ -9,8 +9,8 @@
 #   ./build-utils/getversion.sh export-subst
 #
 # This tells git to replace the format string in the following line with the
-# current short hash upon the calling of the `git archive <hash/tag>` command.
-VERSION_FROM_ARCHIVE=$Format:%h$
+# current hash upon the calling of the `git archive <hash/tag>` command.
+VERSION_FROM_ARCHIVE=$Format:%H$
 
 # The preferred method is to use the git describe command but this is only
 # possible if the .git directory is present.
@@ -23,8 +23,8 @@ if [ x"$VERSION_FROM_GIT" != x ]; then
     echo $VERSION_FROM_GIT; exit 0;
 fi
 
-if [ "$VERSION_FROM_ARCHIVE" != ':%h$' ]; then
-    echo $VERSION_FROM_ARCHIVE; exit 0;
+if [ "$VERSION_FROM_ARCHIVE" != ':%H$' ]; then
+    expr substr $VERSION_FROM_ARCHIVE 1 8; exit 0;
 fi
 
 echo "ERROR: Commit hash detection failure. Dear packager, please figure out"\


### PR DESCRIPTION
Short hashes do not generate reproducible archives; [downloading an archive](https://github.com/luakit/luakit/archive/cb591ba9a466140559a5d9fcd5652b8aea13d80c.tar.gz) a couple times can produce at least 2 versions containing different short hash lengths, which [breaks tools and distros that rely on downloaded archive integrity hashes being stable](https://github.com/NixOS/nixpkgs/issues/84312). Presumably this is because github servers use different git versions/defaults/whatever to produce the archive, or maybe because as the repo history grows a given shorthash length may become ambiguous.

Always substituting the full commit hash (and then truncating it in the script to a fixed short length) addresses the problem.