### PR TITLE
Replace deprecated webkit_web_context_set_network_proxy_settings

### DIFF
--- a/clib/soup.c
+++ b/clib/soup.c
@@ -57,18 +57,18 @@ luaH_soup_index(lua_State *L)
 static void
 luaH_soup_set_proxy_uri(lua_State *L)
 {
-    WebKitWebContext *ctx = web_context_get();
+    WebKitWebsiteDataManager *data_mgr = web_data_manager_get();
     const gchar *new_proxy_uri = lua_isnil(L, 3) ? "default" : luaL_checkstring(L, 3);
     g_free(proxy_uri);
     proxy_uri = g_strdup(new_proxy_uri);
 
     if (!proxy_uri || g_str_equal(proxy_uri, "default")) {
-        webkit_web_context_set_network_proxy_settings(ctx, WEBKIT_NETWORK_PROXY_MODE_DEFAULT, NULL);
+        webkit_website_data_manager_set_network_proxy_settings(data_mgr, WEBKIT_NETWORK_PROXY_MODE_DEFAULT, NULL);
     } else if (g_str_equal(proxy_uri, "no_proxy")) {
-        webkit_web_context_set_network_proxy_settings(ctx, WEBKIT_NETWORK_PROXY_MODE_NO_PROXY, NULL);
+        webkit_website_data_manager_set_network_proxy_settings(data_mgr, WEBKIT_NETWORK_PROXY_MODE_NO_PROXY, NULL);
     } else {
         WebKitNetworkProxySettings *proxy_settings = webkit_network_proxy_settings_new(proxy_uri, NULL);
-        webkit_web_context_set_network_proxy_settings(ctx, WEBKIT_NETWORK_PROXY_MODE_CUSTOM, proxy_settings);
+        webkit_website_data_manager_set_network_proxy_settings(data_mgr, WEBKIT_NETWORK_PROXY_MODE_CUSTOM, proxy_settings);
         webkit_network_proxy_settings_free(proxy_settings);
     }
 }

--- a/web_context.c
+++ b/web_context.c
@@ -26,6 +26,8 @@
 
 /** WebKit context common to all web views */
 static WebKitWebContext *web_context;
+/** WebKit data storage manager for all web views */
+static WebKitWebsiteDataManager *data_mgr;
 /** WebKit process count; default to unlimited */
 static guint process_limit = 0;
 /** Whether the web context startup function has been run */
@@ -33,6 +35,13 @@ static gboolean web_context_started = FALSE;
 
 /** Defined in widgets/webview/downloads.c */
 gboolean download_start_cb(WebKitWebContext *, WebKitDownload *, gpointer);
+
+WebKitWebsiteDataManager *
+web_data_manager_get(void)
+{
+    g_assert(data_mgr);
+    return data_mgr;
+}
 
 WebKitWebContext *
 web_context_get(void)
@@ -65,7 +74,7 @@ website_data_dir_init(void)
     gchar *local_storage_dir = g_build_filename(globalconf.data_dir, "local_storage", NULL);
     gchar *applications_dir = g_build_filename(globalconf.data_dir, "applications", NULL);
 
-    WebKitWebsiteDataManager *data_mgr = webkit_website_data_manager_new(
+    data_mgr = webkit_website_data_manager_new(
             "disk-cache-directory", globalconf.cache_dir,
             "indexeddb-directory", indexeddb_dir,
             "local-storage-directory", local_storage_dir,

--- a/web_context.h
+++ b/web_context.h
@@ -25,6 +25,7 @@
 
 void web_context_init(void);
 void web_context_init_finish(void);
+WebKitWebsiteDataManager *web_data_manager_get(void);
 WebKitWebContext *web_context_get(void);
 WebKitWebContext *web_context_get_private(void);
 guint web_context_process_limit_get(void);


### PR DESCRIPTION
This PR replaces the deprecated `webkit_web_context_set_network_proxy_set` with `webkit_website_data_manager_set_network_proxy_settings`.

It works, but it requires a a new function `WebKitWebsiteDataManager *web_data_manager_get(void)` which I added to `web_context.c`. I leave this PR here to think about it more. I'm not sure where it goes and if more of the context functions have been replaced with WebsiteData functions. If so, it would make sense to invent `website_data.c`.

But maybe I just merge it and think about when more like this comes up. If someone knows more already, let me know.