### PR TITLE
Search LUAKIT_CONFIG_PATH for rc.lua and theme.lua

### DIFF
--- a/clib/luakit.c
+++ b/clib/luakit.c
@@ -739,6 +739,7 @@ luaH_luakit_index(lua_State *L)
       /* push string properties */
       PS_CASE(CACHE_DIR,        globalconf.cache_dir)
       PS_CASE(CONFIG_DIR,       globalconf.config_dir)
+      PS_CASE(XDGPREFIX,        LUAKIT_CONFIG_PATH)
       PS_CASE(DATA_DIR,         globalconf.data_dir)
       PS_CASE(EXECPATH,         globalconf.execpath)
       PS_CASE(CONFPATH,         globalconf.confpath)

--- a/common/luautil.c
+++ b/common/luautil.c
@@ -168,6 +168,9 @@ luaH_add_paths(lua_State *L, const gchar *config_dir)
     if (config_dir)
         g_ptr_array_add(paths, g_strdup(config_dir));
 
+    /* add configured XDGPREFIX */
+    g_ptr_array_add(paths, g_build_filename(LUAKIT_CONFIG_PATH, "luakit", NULL));
+
     /* add system config dirs (see: XDG_CONFIG_DIRS) */
     const gchar* const *config_dirs = g_get_system_config_dirs();
     for (; *config_dirs; config_dirs++)

--- a/common/tokenize.list
+++ b/common/tokenize.list
@@ -274,3 +274,4 @@ win_xid
 replace
 stack
 visible_child
+xdgprefix

--- a/lib/lousy/util.lua
+++ b/lib/lousy/util.lua
@@ -332,7 +332,7 @@ end
 function _M.find_config(f)
     if rstring.match(f, "^/") then return f end
     -- Search locations
-    local paths = { "config/"..f, luakit.config_dir.."/"..f }
+    local paths = { "config/"..f, luakit.config_dir.."/"..f, luakit.xdgprefix.."/luakit/"..f }
     for _, path in ipairs(xdg.system_config_dirs) do
         rtable.insert(paths, path.."/luakit/"..f)
     end

--- a/luah.c
+++ b/luah.c
@@ -211,7 +211,10 @@ luaH_parserc(const gchar *confpath, gboolean run)
     /* search users config dir (see: XDG_CONFIG_HOME) */
     g_ptr_array_add(paths, g_build_filename(globalconf.config_dir, "rc.lua", NULL));
 
-    /* search system config dirs (see: XDG_CONFIG_DIRS) */
+    /* search configured XDGPREFIX */
+    g_ptr_array_add(paths, g_build_filename(LUAKIT_CONFIG_PATH, "luakit", "rc.lua", NULL));
+
+   /* search system config dirs (see: XDG_CONFIG_DIRS) */
     config_dirs = g_get_system_config_dirs();
     for(; *config_dirs; config_dirs++)
         g_ptr_array_add(paths, g_build_filename(*config_dirs, "luakit", "rc.lua", NULL));


### PR DESCRIPTION
When building with a non-standard XDGPREFIX luakit fails to start as it
is unable to find rc.lua and then later theme.lua if the user lacks
these files in the configured path.

Add the configured LUAKIT_CONFIG_PATH to the list of paths to look in
for a smoother experience with custom installs.