### PR TITLE
Mention FAQ, Quick Start, etc on :help

### DIFF
--- a/lib/help_chrome.lua
+++ b/lib/help_chrome.lua
@@ -41,6 +41,18 @@ local index_html_template = [==[
             license.  It is primarily targeted at power users, developers and any people with too much time
             on their hands who want to have fine-grained control over their web browser&rsquo;s behaviour and
             interface.</p>
+            <p> 
+            Useful (though outdated) documentation can be found here:
+            <ul>
+            <li><a href="doc/pages/01-authors.html">Authors</a></li>
+            <li><a href="doc/pages/02-faq.html">Frequently Asked Questions</a></li>
+            <li><a href="doc/pages/03-quick-start-guide.html">Quick-start Guide</a></li>
+            <li><a href="doc/pages/04-migration-guide.html">Migration Guide</a></li>
+            <li><a href="doc/pages/05-configuration.html">Files and Directories</a></li>
+            <li><a href="doc/pages/06-tests.html">Running the Test Suite</a></li>
+            <li><a href="doc/pages/07-build-debian-package.html">Building a Debian Package</a></li>
+            </ul>
+            </p>
         <h2>Configuration</h2>
         <h3>Settings</h3>
         <p>The available settings are displayed at:</p>


### PR DESCRIPTION
The default luakit homepage (`luakit.github.io`) has a `Documentation` link which takes users to the API Documentation page.
This page has (in addition to API Documentation) links to a number of pages which are of use to
new and prospective users, including the Quick Start Guide and the FAQ.
These pages, although useful, are arguably not API Documentation, and should probably be filed elsewhere.

By contrast, if a user misses the Documentation link at the top of the home page, but has the nous to type in `:help`,
they get useful information on which `luakit://` chrome pages are available, with Settings and Binds pointed out explicitly,
but they will only see the Quick Start Guide, FAQ etc if they navigate the API Index link.
A new user who would benefit from these pages, is unlikely to click a link to the API Documentation,
and so is likely to not see these pages.

This PR duplicates the links from the top of the API Doc page to the top of the `:help` page.  