### PR TITLE
Disabled matching masked password field content when hinting

### DIFF
--- a/lib/select_wm.lua
+++ b/lib/select_wm.lua
@@ -283,8 +283,11 @@ local function frame_find_hints(page, frame, elements)
         local rbb = get_element_bb_if_visible(element,wbb, page)
 
         if rbb then
-            local text = element.text_content
-            if text == "" then text = element.value or "" end
+            local text = ""
+            if element.type ~= "password" then
+                text = element.text_content
+                if text == "" then text = element.value or "" end
+            end
             if text == "" then text = element.attr.placeholder or "" end
             hints[#hints+1] = { elem = element, bb = rbb, text = text }
         end


### PR DESCRIPTION
As discussed in https://github.com/luakit/luakit/issues/1030, password fields, i.e. `input` elements with `type="password"`, were being matched based on their masked content during hint generation.  
This PR changes the matching behaviour to ignore `text_content` and `value` for any element with `type="password"`.