### PR TITLE
Webkit2gtk 4.1 (#1025)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Develop
+
+### Fixed
+
+- Update uri handling for SOUP3
+
 ## [2.3.3]
 
 ### Fixed

--- a/luakit.c
+++ b/luakit.c
@@ -130,8 +130,12 @@ parseopts(int *argc, gchar *argv[], gboolean **nonblock)
     /* print version and exit */
     if (version_only) {
         g_printf("luakit %s\n", VERSION);
-        g_printf("  built with webkit %i.%i.%i ", WEBKIT_MAJOR_VERSION, WEBKIT_MINOR_VERSION, WEBKIT_MICRO_VERSION);
+        g_printf("  built with: webkit %i.%i.%i ", WEBKIT_MAJOR_VERSION, WEBKIT_MINOR_VERSION, WEBKIT_MICRO_VERSION);
         g_printf("(installed version: %u.%u.%u)\n", webkit_get_major_version(), webkit_get_minor_version(), webkit_get_micro_version());
+        g_printf("                 GTK %i.%i.%i \n", GTK_MAJOR_VERSION, GTK_MINOR_VERSION, GTK_MICRO_VERSION);
+        g_printf("                GLIB %i.%i.%i \n", GLIB_MAJOR_VERSION, GLIB_MINOR_VERSION, GLIB_MICRO_VERSION);
+        g_printf("                SOUP %i.%i.%i \n", SOUP_MAJOR_VERSION, SOUP_MINOR_VERSION, SOUP_MICRO_VERSION);
+
         exit(EXIT_SUCCESS);
     }
 

--- a/widgets/webview/auth.c
+++ b/widgets/webview/auth.c
@@ -22,9 +22,6 @@
 #include "luah.h"
 
 #include <gtk/gtk.h>
-#include <libsoup/soup-auth.h>
-#include <libsoup/soup-session-feature.h>
-//#include <libsoup/soup-uri.h>
 
 typedef struct {
     WebKitAuthenticationRequest *request;


### PR DESCRIPTION
Ok, so here's the next iteration towards closing #1025.
In my hands, this builds and runs against both webkit2gtk-4.1 & 4.0,
so it should be pullable into develop, pending code review and testing.
It's only been tested on Debian Sid.

### common/clib/soup.h:
- This uses `g_uri_join_with_user()` to build the URI string.
  This is somewhat more elegant, and avoids creating a GUri object.
- It no longer produces URIs with passwords, to retain consistency with previous behaviour.
- It dances around the g_uri_* functions using -1 in place of a missing port.
- It adds a soup version check which includes the appropriate header,
  and #defines a bitmap that's absent in soup2.

I'm not sure why `common/clib/soup.h`'s functions are declared static, or are in a header file at all.
They had previously been in `clib/soup.c`,
but were moved to `common/clib/soup.h` in a283b1b99 ("Split soup library into UI, Web, and shared parts").

### common/property.c
- Removed the comments with the rationales for the changes.
- Duplicate the soup version test from `common/clib/soup.h`.

I'm pretty sure that the `URI:` cases in `common/property.c` are never triggered, as a `property_value_t` of `URI` never gets used.
This makes it more difficult to confirm that these clauses are functioning correctly.

### luakit.c:
- Added some extra information to the `--version` command line output.
It was useful for me to figure out what library version i needed to test,
and might be of value in the future, but is certainly not required for SOUP3 compilation.

### widgets/webview/auth.c
- Remove #includes for system soup headers.
One no longer exists with soup3, the other two don't seem necessary for compilation.
They'd been there since 2011, and i suspect have become redundant ("soup" doesn't appear in the file).
However, i haven't actually tested http authentication with them deleted.

### CHANGELOG.md
- Note the changes.