### PR TITLE
Fix "package.path is not a string" error on latest LuaJIT

### DIFF
--- a/common/luautil.c
+++ b/common/luautil.c
@@ -141,12 +141,12 @@ void
 luaH_add_paths(lua_State *L, const gchar *config_dir)
 {
     lua_getglobal(L, "package");
-    if(LUA_TTABLE != lua_type(L, 1)) {
+    if(LUA_TTABLE != lua_type(L, -1)) {
         warn("package is not a table");
         return;
     }
-    lua_getfield(L, 1, "path");
-    if(LUA_TSTRING != lua_type(L, 2)) {
+    lua_getfield(L, -1, "path");
+    if(LUA_TSTRING != lua_type(L, -1)) {
         warn("package.path is not a string");
         lua_pop(L, 1);
         return;
@@ -193,7 +193,7 @@ luaH_add_paths(lua_State *L, const gchar *config_dir)
     g_ptr_array_free(paths, TRUE);
 
     /* package.path = "concatenated string" */
-    lua_setfield(L, 1, "path");
+    lua_setfield(L, -2, "path");
 
     /* remove package module from stack */
     lua_pop(L, 1);


### PR DESCRIPTION
When luakit is compiled against the current v2.1 branch of LuaJIT, it fails to start because "package.path is not a string", so it can't add the needed searchpaths for Lua modules. (This can be worked around by setting the `LUA_PATH` environment variable, but that's far from being an ideal solution.)

Apparently, the function `luaH_add_paths` assumed that "package" would always be in position 1 on the stack after calling `lua_getglobal`, which was valid on LuaJIT 2.0.5, but (for some reason I can't explain) doesn't hold on the newer version. It seems the fix is simply to use relative offsets from the stack top instead, i.e. pass negative numbers to `lua_getfield`, `lua_type` and `lua_setfield`.

I think this qualifies as a "tweak needed to get luakit to run"; that said, I should note that I know very little about Lua (just the bare minimum to configure luakit itself), and I knew nothing about the Lua C API until I started digging into this yesterday…