### PR TITLE
Add pdfjs switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Manage dom events with luakit signals.
+- An enable_pdfjs setting to go back to letting viewpdf handle PDFs.
 
 ### Changed
 

--- a/common/tokenize.list
+++ b/common/tokenize.list
@@ -124,6 +124,7 @@ serif_font_family
 send_key
 set_dark_mode
 set_default_size
+set_pdfjs
 set_title
 show
 show_border

--- a/lib/viewpdf.lua
+++ b/lib/viewpdf.lua
@@ -1,7 +1,8 @@
 --- Automatic PDF viewing.
 --
 -- This module automatically downloads PDF files to the luakit cache directory,
--- and opens them with `xdg-open`.
+-- and opens them with `xdg-open`.  You must disable the enable_pdfjs
+-- setting for this to work.
 --
 -- @module viewpdf
 -- @copyright 2016 Aidan Holm <aidanholm@gmail.com>

--- a/lib/webview.lua
+++ b/lib/webview.lua
@@ -575,7 +575,7 @@ local webview_settings = {
     },
     ["application.enable_pdfjs"] = {
         type = "boolean",
-        default = false,
+        default = true,
         desc = [=[
             Whether to load PDFs in a built-in javascript renderer.
             The default is to pass them on to the OS.  This setting

--- a/lib/webview.lua
+++ b/lib/webview.lua
@@ -145,6 +145,12 @@ local init_funcs = {
             end
         end)
     end,
+
+    enable_pdfjs = function (view)
+        local pdfjs_enabled =
+            settings.get_setting("application.enable_pdfjs")
+        view:set_pdfjs(pdfjs_enabled or false)
+    end,
 }
 
 --- These methods are present when you index a window instance and no window
@@ -567,6 +573,14 @@ local webview_settings = {
             Disabling this setting is only useful to conserve memory.
         ]=],
     },
+    ["application.enable_pdfjs"] = {
+        type = "boolean",
+        default = false,
+        desc = [=[
+            Whether to load PDFs in a built-in javascript renderer.
+            The default is to pass them on to the OS.  This setting
+            only becomes active in new tabs.]=]
+    },
     ["webview.enable_plugins"] = {
         type = "boolean",
         default = true,
@@ -717,8 +731,9 @@ settings.register_settings({
 
 _M.add_signal("init", function (view)
     local set = function (wv, k, v, match)
-        if v ~= nil then
-            k = k:sub(9) -- Strip off "webview." prefix
+        -- hand through webview.-prefixed settings
+        if v ~= nil and k:find('webview.', 1, true) then
+            k = k:sub(9) -- Strip off prefix
             if k == "zoom_level" then v = v/100.0 end
             if k == "user_agent" and v == "" then v = nil end
             match = match and (" (matched '"..match.."')") or ""

--- a/widgets/webview.c
+++ b/widgets/webview.c
@@ -759,6 +759,29 @@ permission_request_cb(WebKitWebView *UNUSED(v), WebKitPermissionRequest *request
 }
 
 static gint
+luaH_webview_set_pdfjs(lua_State *L)
+{
+    webview_data_t *d = luaH_checkwvdata(L, 1);
+    gboolean enabled = luaH_checkboolean(L, 2);
+
+    g_autoptr(WebKitFeatureList) features
+        = webkit_settings_get_all_features();
+    WebKitSettings *settings = webkit_web_view_get_settings(d->view);
+
+    for (gsize i = 0; i < webkit_feature_list_get_length(features); i++) {
+        WebKitFeature *feature = webkit_feature_list_get(features, i);
+        if (!strcmp(
+                webkit_feature_get_identifier(feature),
+                "PdfJSViewer")) {
+            webkit_settings_set_feature_enabled(settings, feature, enabled);
+            break;
+        }
+    }
+
+    return 0;
+}
+
+static gint
 luaH_webview_index(lua_State *L, widget_t *w, luakit_token_t token)
 {
     webview_data_t *d = w->data;
@@ -798,6 +821,7 @@ luaH_webview_index(lua_State *L, widget_t *w, luakit_token_t token)
       PF_CASE(CLOSE_INSPECTOR,      luaH_webview_close_inspector)
 
       PF_CASE(ALLOW_CERTIFICATE,    luaH_webview_allow_certificate)
+      PF_CASE(SET_PDFJS,            luaH_webview_set_pdfjs)
 
       /* push string properties */
       PS_CASE(HOVERED_URI,          d->hover)


### PR DESCRIPTION
This is an attempt to address bug #1052; I'm (well: my machine is) tired of rebuilding luakit to patch out pdf.js.

What this does now is follow Michael's recipe on https://bugs.webkit.org/show_bug.cgi?id=260019#c4 (comment 4) to unconditionally turn off pdfjs using some ugly custom code in widgets/webview.c; that works on a PoC level.

However, assuming that not everyone is as abhorred by pdf.js as I am, this would now need to be made configurable.  I *think* we will still need C code for this, as webkit_settings_get_all_features does not seem to be exposed to lua (and I don't think it should). But I have not found a way to trick that C code into settings.lua; actually, I have not even worked out how settings.lua talks to webkit in "normal" cases.

Does anyone here still understand settings.lua?  Well enough to figure out whether we can have a setting that simply calls a C function on toggling, even?