### PR TITLE
Correct regex compile options type if none are passed

### DIFF
--- a/common/clib/soup.h
+++ b/common/clib/soup.h
@@ -161,7 +161,7 @@ luaH_soup_parse_uri(lua_State *L)
 static void
 soup_lib_setup_common(void)
 {
-    scheme_reg = g_regex_new("^[a-z][a-z0-9\\+\\-\\.]*:", NULL, 0, NULL);
+    scheme_reg = g_regex_new("^[a-z][a-z0-9\\+\\-\\.]*:", 0, 0, NULL);
 }
 
 #endif

--- a/log.c
+++ b/log.c
@@ -222,7 +222,7 @@ va_log(log_level_t lvl, const gchar *fct, const gchar *fmt, va_list ap)
     static GRegex *indent_lines_reg;
     if (!indent_lines_reg) {
         GError *err = NULL;
-        indent_lines_reg = g_regex_new("\n", NULL, 0, &err);
+        indent_lines_reg = g_regex_new("\n", 0, 0, &err);
         g_assert_no_error(err);
     }
     gchar *wrapped = g_regex_replace_literal(indent_lines_reg, msg, -1, 0, "\n" LOG_IND, 0, NULL);


### PR DESCRIPTION
compile options are of enum type so don't try to pass pointer instead. fixes compile failures (GCC13):

log.c:225:46: error: incompatible type for argument 2 of 'g_regex_new'
./common/clib/soup.h:164:59: error: incompatible type for argument 2 of 'g_regex_new

Fixes: e400cda67c81 ("Remove G_REGEX_OPTIMIZE")