### PR TITLE
Install lua dependencies via apt instead of luarocks.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,12 +16,7 @@ jobs:
     - name: Install depenencies
       run: |
         sudo apt-get update
-        sudo apt-get install luajit libluajit-5.1-dev libjavascriptcoregtk-4.0-dev libwebkit2gtk-4.1-dev libgtk-3-dev libglib2.0-dev luarocks
-    - name: Install lua dependencies
-      run: |
-        sudo luarocks --lua-version 5.1 install luafilesystem
-        sudo luarocks --lua-version 5.1 install luassert
-        sudo luarocks --lua-version 5.1 install luacheck
+        sudo apt-get install luajit libluajit-5.1-dev libjavascriptcoregtk-4.0-dev libwebkit2gtk-4.1-dev libgtk-3-dev libglib2.0-dev lua-check lua-luassert lua-filesystem lua-socket
     - name: make
       run: make
     - name: make run-tests


### PR DESCRIPTION
This avoids installing luarocks, which has a few extra deps of its own.

These apt packages contain four copies, for lua 5.1 through 5.4, but that should be much less expensive.