### PR TITLE
noscript: update policy on the navigation-request signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Fixed undoclose bug (and likely some other segfaults)
 - Fixed luaH_init() implicit prototype warning
+- Fixed refresh being needed for the correct NoScript policy to take effect.
 
 ### Contributors to this release:
 

--- a/lib/noscript.lua
+++ b/lib/noscript.lua
@@ -197,10 +197,8 @@ end
 
 webview.add_signal("init", function (view)
     -- Update on new resource load
-    view:add_signal("policy-decided", function (v, _, _, decision)
-        if decision == "use" then
-            update_webview_blocking(v)
-        end
+    view:add_signal("navigation-request", function (v, _, _)
+        update_webview_blocking(v)
     end)
 
     -- Update on history navigation


### PR DESCRIPTION
Replace the policy-decided signal which is never emitted with
navigation-request. This should resolve some JavaScript policy issues
such as the page needing to be refreshed for the correct policy to take
effect.

---
Fixes: #649
