### PR TITLE
follow: add <summary> as a clickable element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Manage dom events with luakit signals.
 - An enable_pdfjs setting to go back to letting viewpdf handle PDFs.
+- `<summary>` elements are now hinted as clickable.
 
 ### Changed
 

--- a/lib/follow.lua
+++ b/lib/follow.lua
@@ -342,7 +342,7 @@ add_binds("follow", {
 -- @type {[string]=string}
 -- @readwrite
 _M.selectors = {
-    clickable = 'a, area, textarea, select, input:not([type=hidden]), button, label',
+    clickable = 'a, area, textarea, select, input:not([type=hidden]), button, label, summary',
     -- Elements that can be clicked.
     focus = 'a, area, textarea, select, input:not([type=hidden]), button, body, applet, object',
     -- Elements that can be given input focus.


### PR DESCRIPTION
Clicking this element will toggle the visibility of the content of the
containing <details> element.
