### PR TITLE
Status bar & Tablist fullscreen settings option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - `status_bar.fullscreen_visible` setting to allow status bar to be visible in fullscreen  
+- `tablist.fullscreen_visible` setting to allow the tablist to be visible in fullscreen  
 
 ## [2.4.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+##[Unreleased]
+
+### Added
+- `status_bar.fullscreen_visible` setting to allow status bar to be visible in fullscreen  
+
 ## [2.4.0]
 
 ### Added

--- a/lib/window.lua
+++ b/lib/window.lua
@@ -349,7 +349,8 @@ _M.methods = {
     end,
 
     update_sbar_visibility = function (w)
-        if (not w.win.fullscreen) or w_priv[w].prompt_text or w_priv[w].input_text then
+        if (not w.win.fullscreen) or w_priv[w].prompt_text or w_priv[w].input_text 
+	    or settings.get_setting("status_bar.fullscreen_visible") then
             w.bar_layout.visible = true
         else
             w.bar_layout.visible = false
@@ -790,6 +791,11 @@ settings.register_settings({
         type = "boolean",
         default = false,
         desc = "Perfer dark CSS when the website supports it (requires restart).",
+    },
+    ["status_bar.fullscreen_visible"] = {
+        type = "boolean",
+        default = false,
+        desc = "Whether to show the status bar when fullscreen.",
     },
     ["window.act_on_synthetic_keys"] = {
         type = "boolean",

--- a/lib/window.lua
+++ b/lib/window.lua
@@ -274,7 +274,9 @@ local init_funcs = {
     hide_ui_on_fullscreen = function (w)
         w.win:add_signal("property::fullscreen", function (win)
             w:update_sbar_visibility()
-            w.tablist.visible = not win.fullscreen
+            if not settings.get_setting("tablist.fullscreen_visible") then
+                w.tablist.visible = not win.fullscreen
+	    end
         end)
     end,
 
@@ -796,6 +798,11 @@ settings.register_settings({
         type = "boolean",
         default = false,
         desc = "Whether to show the status bar when fullscreen.",
+    },
+    ["tablist.fullscreen_visible"] = {
+        type = "boolean",
+        default = false,
+        desc = "Whether to show the tablist when fullscreen.",
     },
     ["window.act_on_synthetic_keys"] = {
         type = "boolean",


### PR DESCRIPTION
This PR provides 2 settings `status_bar.fullscreen_visible` and `tablist.fullscreen_visible` to allow the user to show/hide the status bar or tab list in fullscreen.

Other userconf.lua solutions found in the wiki/issues for the status bar have not worked consistently, with the status bar showing in full screen at first and then disappearing.

This PR allows either bar to show in fullscreen consistently. 

The default for both status bar and tablist remains as false. 
The funtionality of `tablist.visibility` works the same when `tablist.fullscreen_visible` is used.