### PR TITLE
Fix pdfjs knob

### DIFF
--- a/widgets/webview.c
+++ b/widgets/webview.c
@@ -770,7 +770,11 @@ luaH_webview_set_pdfjs(lua_State *L)
         WebKitFeature *feature = webkit_feature_list_get(features, i);
         if (!strcmp(
                 webkit_feature_get_identifier(feature),
+#if WEBKIT_CHECK_VERSION(2, 43, 1)
+                "PDFJSViewer")) {
+#else
                 "PdfJSViewer")) {
+#endif
             webkit_settings_set_feature_enabled(settings, feature, enabled);
             break;
         }


### PR DESCRIPTION
This fixes the pdf.js-disabling setting (upstream has changed the name of the internal feature).