### PR TITLE
Rewrite dom_element bindings with JSC; harden IPC and build

### DIFF
--- a/build-utils/getversion-test.sh
+++ b/build-utils/getversion-test.sh
@@ -1,0 +1,642 @@
+#!/bin/sh
+# Comprehensive test suite for getversion.sh
+#
+# Usage: ./getversion-test.sh <empty-test-directory>
+#
+# This script creates various git scenarios and validates getversion.sh output.
+
+set -e
+
+# Colors for output (disable if not a terminal)
+if [ -t 1 ]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[0;33m'
+    NC='\033[0m' # No Color
+else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    NC=''
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GETVERSION="$SCRIPT_DIR/getversion.sh"
+PASS=0
+FAIL=0
+
+usage() {
+    echo "Usage: $0 <empty-test-directory>"
+    echo ""
+    echo "Creates git scenarios in the specified directory to test getversion.sh"
+    exit 1
+}
+
+log_pass() {
+    PASS=$((PASS + 1))
+    printf "${GREEN}PASS${NC}: %s\n" "$1"
+}
+
+log_fail() {
+    FAIL=$((FAIL + 1))
+    printf "${RED}FAIL${NC}: %s\n" "$1"
+    printf "       Expected: %s\n" "$2"
+    printf "       Got:      %s\n" "$3"
+}
+
+log_info() {
+    printf "${YELLOW}TEST${NC}: %s\n" "$1"
+}
+
+# Run getversion.sh and capture output
+run_getversion() {
+    sh "$GETVERSION" 2>/dev/null || true
+}
+
+# Check if output matches expected pattern
+# $1 = test name
+# $2 = expected pattern (grep -E regex)
+# $3 = actual output
+check_pattern() {
+    name="$1"
+    pattern="$2"
+    actual="$3"
+
+    if echo "$actual" | grep -qE "$pattern"; then
+        log_pass "$name"
+        return 0
+    else
+        log_fail "$name" "pattern: $pattern" "$actual"
+        return 1
+    fi
+}
+
+# Check exact match
+# $1 = test name
+# $2 = expected value
+# $3 = actual output
+check_exact() {
+    name="$1"
+    expected="$2"
+    actual="$3"
+
+    if [ "$actual" = "$expected" ]; then
+        log_pass "$name"
+        return 0
+    else
+        log_fail "$name" "$expected" "$actual"
+        return 1
+    fi
+}
+
+# Validate arguments
+if [ $# -ne 1 ]; then
+    usage
+fi
+
+TEST_DIR="$1"
+
+if [ ! -d "$TEST_DIR" ]; then
+    echo "Error: Directory '$TEST_DIR' does not exist"
+    exit 1
+fi
+
+if [ "$(ls -A "$TEST_DIR" 2>/dev/null)" ]; then
+    echo "Error: Directory '$TEST_DIR' is not empty"
+    exit 1
+fi
+
+if [ ! -f "$GETVERSION" ]; then
+    echo "Error: getversion.sh not found at $GETVERSION"
+    exit 1
+fi
+
+# Convert to absolute path
+TEST_DIR="$(cd "$TEST_DIR" && pwd)"
+
+echo "=========================================="
+echo "getversion.sh Test Suite"
+echo "=========================================="
+echo "Test directory: $TEST_DIR"
+echo "Script under test: $GETVERSION"
+echo ""
+
+# Copy getversion.sh to test directory
+cp "$GETVERSION" "$TEST_DIR/getversion.sh"
+
+# ===========================================
+# Test 1: No git repository at all
+# ===========================================
+log_info "No git repository (should fail)"
+cd "$TEST_DIR"
+mkdir -p test1_no_git
+cd test1_no_git
+cp "$TEST_DIR/getversion.sh" .
+
+output=$(sh ./getversion.sh 2>&1) || true
+if echo "$output" | grep -q "ERROR"; then
+    log_pass "No git repo returns error"
+else
+    log_fail "No git repo returns error" "ERROR message" "$output"
+fi
+
+# ===========================================
+# Test 2: Git repo with no tags, clean
+# ===========================================
+log_info "Git repo, no tags, clean working tree"
+cd "$TEST_DIR"
+mkdir -p test2_no_tags
+cd test2_no_tags
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git config commit.gpgsign false
+echo "content" > file.txt
+git add file.txt
+git commit -q -m "Initial commit"
+cp "$TEST_DIR/getversion.sh" .
+
+output=$(run_getversion)
+check_pattern "No tags clean -> 0.0.0-<hash>" "^0\.0\.0-[0-9a-f]{7}$" "$output"
+
+# ===========================================
+# Test 3: Git repo with no tags, dirty
+# ===========================================
+log_info "Git repo, no tags, dirty working tree"
+cd "$TEST_DIR/test2_no_tags"
+echo "modified" >> file.txt
+
+output=$(run_getversion)
+check_pattern "No tags dirty -> 0.0.0-<hash>-dirty" "^0\.0\.0-[0-9a-f]{7}-dirty$" "$output"
+
+# Clean up
+git checkout -q -- file.txt
+
+# ===========================================
+# Test 4: Git repo with tag (exact match)
+# ===========================================
+log_info "Git repo, on exact tag, clean"
+cd "$TEST_DIR"
+mkdir -p test4_with_tag
+cd test4_with_tag
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git config commit.gpgsign false
+echo "content" > file.txt
+git add file.txt
+git commit -q -m "Initial commit"
+git tag "1.0.0"
+cp "$TEST_DIR/getversion.sh" .
+
+output=$(run_getversion)
+check_exact "Exact tag -> 1.0.0" "1.0.0" "$output"
+
+# ===========================================
+# Test 5: Git repo with tag, dirty
+# ===========================================
+log_info "Git repo, on exact tag, dirty"
+cd "$TEST_DIR/test4_with_tag"
+echo "modified" >> file.txt
+
+output=$(run_getversion)
+check_exact "Exact tag dirty -> 1.0.0-dirty" "1.0.0-dirty" "$output"
+
+# Clean up
+git checkout -q -- file.txt
+
+# ===========================================
+# Test 6: Git repo with tag + commits after
+# ===========================================
+log_info "Git repo, commits after tag, clean"
+cd "$TEST_DIR"
+mkdir -p test6_tag_plus_commits
+cd test6_tag_plus_commits
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git config commit.gpgsign false
+echo "content" > file.txt
+git add file.txt
+git commit -q -m "Initial commit"
+git tag "2.0.0"
+echo "more content" >> file.txt
+git add file.txt
+git commit -q -m "Second commit"
+cp "$TEST_DIR/getversion.sh" .
+
+output=$(run_getversion)
+check_pattern "Tag + commits -> 2.0.0-1-g<hash>" "^2\.0\.0-[0-9]+-g[0-9a-f]{7}$" "$output"
+
+# ===========================================
+# Test 7: Git repo with tag + commits, dirty
+# ===========================================
+log_info "Git repo, commits after tag, dirty"
+cd "$TEST_DIR/test6_tag_plus_commits"
+echo "uncommitted" >> file.txt
+
+output=$(run_getversion)
+check_pattern "Tag + commits dirty -> 2.0.0-1-g<hash>-dirty" "^2\.0\.0-[0-9]+-g[0-9a-f]{7}-dirty$" "$output"
+
+# Clean up
+git checkout -q -- file.txt
+
+# ===========================================
+# Test 8: Git worktree checkout
+# ===========================================
+log_info "Git worktree checkout"
+cd "$TEST_DIR"
+mkdir -p test8_worktree_main
+cd test8_worktree_main
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git config commit.gpgsign false
+echo "content" > file.txt
+git add file.txt
+git commit -q -m "Initial commit"
+git tag "3.0.0"
+git branch feature
+
+# Create worktree
+cd "$TEST_DIR"
+git -C test8_worktree_main worktree add "$TEST_DIR/test8_worktree_feature" feature -q
+
+cd "$TEST_DIR/test8_worktree_feature"
+cp "$TEST_DIR/getversion.sh" .
+
+output=$(run_getversion)
+check_exact "Worktree -> 3.0.0" "3.0.0" "$output"
+
+# Verify .git is a file, not directory
+if [ -f .git ] && [ ! -d .git ]; then
+    log_pass "Worktree has .git file (not directory)"
+else
+    log_fail "Worktree has .git file (not directory)" ".git is file" ".git is directory or missing"
+fi
+
+# ===========================================
+# Test 9: Git worktree, dirty
+# ===========================================
+log_info "Git worktree, dirty"
+cd "$TEST_DIR/test8_worktree_feature"
+echo "modified" >> file.txt
+
+output=$(run_getversion)
+check_exact "Worktree dirty -> 3.0.0-dirty" "3.0.0-dirty" "$output"
+
+# Clean up
+git checkout -q -- file.txt
+
+# ===========================================
+# Test 10: .git directory missing (removed)
+# ===========================================
+log_info ".git directory removed"
+cd "$TEST_DIR"
+mkdir -p test10_no_dotgit
+cd test10_no_dotgit
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git config commit.gpgsign false
+echo "content" > file.txt
+git add file.txt
+git commit -q -m "Initial commit"
+cp "$TEST_DIR/getversion.sh" .
+
+# Remove .git
+rm -rf .git
+
+output=$(sh ./getversion.sh 2>&1) || true
+if echo "$output" | grep -q "ERROR"; then
+    log_pass ".git removed returns error"
+else
+    log_fail ".git removed returns error" "ERROR message" "$output"
+fi
+
+# ===========================================
+# Test 11: Lightweight tag vs annotated tag
+# ===========================================
+log_info "Annotated tag"
+cd "$TEST_DIR"
+mkdir -p test11_annotated_tag
+cd test11_annotated_tag
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git config commit.gpgsign false
+echo "content" > file.txt
+git add file.txt
+git commit -q -m "Initial commit"
+git tag -a "4.0.0" -m "Release 4.0.0"
+cp "$TEST_DIR/getversion.sh" .
+
+output=$(run_getversion)
+check_exact "Annotated tag -> 4.0.0" "4.0.0" "$output"
+
+# ===========================================
+# Test 12: Multiple tags (latest should win)
+# ===========================================
+log_info "Multiple tags on same commit"
+cd "$TEST_DIR"
+mkdir -p test12_multi_tag
+cd test12_multi_tag
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git config commit.gpgsign false
+echo "content" > file.txt
+git add file.txt
+git commit -q -m "Initial commit"
+git tag "5.0.0"
+git tag "5.0.1"
+cp "$TEST_DIR/getversion.sh" .
+
+output=$(run_getversion)
+# Either tag is acceptable
+if [ "$output" = "5.0.0" ] || [ "$output" = "5.0.1" ]; then
+    log_pass "Multiple tags -> one of them (got: $output)"
+else
+    log_fail "Multiple tags -> one of them" "5.0.0 or 5.0.1" "$output"
+fi
+
+# ===========================================
+# Test 13: Tag with 'v' prefix
+# ===========================================
+log_info "Tag with v prefix"
+cd "$TEST_DIR"
+mkdir -p test13_v_prefix
+cd test13_v_prefix
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git config commit.gpgsign false
+echo "content" > file.txt
+git add file.txt
+git commit -q -m "Initial commit"
+git tag "v6.0.0"
+cp "$TEST_DIR/getversion.sh" .
+
+output=$(run_getversion)
+check_exact "v-prefixed tag -> v6.0.0" "v6.0.0" "$output"
+
+# ===========================================
+# Test 14: Staged but uncommitted changes
+# ===========================================
+log_info "Staged but uncommitted changes"
+cd "$TEST_DIR"
+mkdir -p test14_staged
+cd test14_staged
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git config commit.gpgsign false
+echo "content" > file.txt
+git add file.txt
+git commit -q -m "Initial commit"
+git tag "7.0.0"
+cp "$TEST_DIR/getversion.sh" .
+echo "new" > newfile.txt
+git add newfile.txt
+
+output=$(run_getversion)
+check_exact "Staged changes -> 7.0.0-dirty" "7.0.0-dirty" "$output"
+
+# Clean up
+git reset -q HEAD newfile.txt
+rm -f newfile.txt
+
+# ===========================================
+# Test 15: Untracked files (should NOT be dirty)
+# ===========================================
+log_info "Untracked files only"
+cd "$TEST_DIR"
+mkdir -p test15_untracked
+cd test15_untracked
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git config commit.gpgsign false
+echo "content" > file.txt
+git add file.txt
+git commit -q -m "Initial commit"
+git tag "8.0.0"
+cp "$TEST_DIR/getversion.sh" .
+echo "untracked" > untracked.txt
+
+output=$(run_getversion)
+check_exact "Untracked files -> 8.0.0 (not dirty)" "8.0.0" "$output"
+
+# ===========================================
+# Test 16: Detached HEAD at tag
+# ===========================================
+log_info "Detached HEAD at tag"
+cd "$TEST_DIR"
+mkdir -p test16_detached
+cd test16_detached
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git config commit.gpgsign false
+echo "content" > file.txt
+git add file.txt
+git commit -q -m "Initial commit"
+git tag "9.0.0"
+echo "more" >> file.txt
+git add file.txt
+git commit -q -m "Second commit"
+git checkout -q 9.0.0
+cp "$TEST_DIR/getversion.sh" .
+
+output=$(run_getversion)
+check_exact "Detached HEAD at tag -> 9.0.0" "9.0.0" "$output"
+
+# ===========================================
+# Test 17: Detached HEAD not at tag
+# ===========================================
+log_info "Detached HEAD not at tag"
+cd "$TEST_DIR"
+mkdir -p test17_detached_no_tag
+cd test17_detached_no_tag
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git config commit.gpgsign false
+echo "content" > file.txt
+git add file.txt
+git commit -q -m "Initial commit"
+echo "more" >> file.txt
+git add file.txt
+git commit -q -m "Second commit"
+git tag "10.0.0"
+git checkout -q HEAD~1
+cp "$TEST_DIR/getversion.sh" .
+
+output=$(run_getversion)
+check_pattern "Detached HEAD no tag -> 0.0.0-<hash>" "^0\.0\.0-[0-9a-f]{7}$" "$output"
+
+# ===========================================
+# Test 18: Shallow clone
+# ===========================================
+log_info "Shallow clone"
+cd "$TEST_DIR"
+mkdir -p test18_source
+cd test18_source
+git init -q --bare
+
+cd "$TEST_DIR"
+mkdir -p test18_work
+cd test18_work
+git clone -q "$TEST_DIR/test18_source" repo
+cd repo
+git config user.email "test@test.com"
+git config user.name "Test"
+git config commit.gpgsign false
+echo "content" > file.txt
+git add file.txt
+git commit -q -m "Initial commit"
+git tag "11.0.0"
+echo "more" >> file.txt
+git add file.txt
+git commit -q -m "Second commit"
+git push -q origin master --tags 2>/dev/null || git push -q origin main --tags 2>/dev/null || true
+
+cd "$TEST_DIR"
+git clone -q --depth 1 "$TEST_DIR/test18_source" test18_shallow || true
+if [ -d test18_shallow ]; then
+    cd test18_shallow
+    cp "$TEST_DIR/getversion.sh" .
+
+    output=$(run_getversion)
+    # Shallow clones may or may not have tag info depending on git version
+    if echo "$output" | grep -qE "^(11\.0\.0|0\.0\.0-)"; then
+        log_pass "Shallow clone -> version or fallback (got: $output)"
+    else
+        log_fail "Shallow clone -> version or fallback" "11.0.0 or 0.0.0-<hash>" "$output"
+    fi
+else
+    log_pass "Shallow clone (skipped - no remote)"
+fi
+
+# ===========================================
+# Test 19: Pre-release tag format
+# ===========================================
+log_info "Pre-release tag (semver)"
+cd "$TEST_DIR"
+mkdir -p test19_prerelease
+cd test19_prerelease
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git config commit.gpgsign false
+echo "content" > file.txt
+git add file.txt
+git commit -q -m "Initial commit"
+git tag "12.0.0-beta.1"
+cp "$TEST_DIR/getversion.sh" .
+
+output=$(run_getversion)
+check_exact "Pre-release tag -> 12.0.0-beta.1" "12.0.0-beta.1" "$output"
+
+# ===========================================
+# Test 20: Archive fallback simulation
+# ===========================================
+log_info "Archive fallback (simulated)"
+cd "$TEST_DIR"
+mkdir -p test20_archive
+cd test20_archive
+
+# Create a modified getversion.sh that simulates archive substitution
+cat > getversion_archive.sh << 'SCRIPT'
+#!/bin/sh
+VERSION_FROM_ARCHIVE='abc1234567890def1234567890abcdef12345678'
+
+if [ -d .git ] || { [ -f .git ] && grep -q '^gitdir:' .git 2>/dev/null; }
+then
+    VERSION_FROM_GIT=$(git describe --tags --always --dirty 2>/dev/null)
+fi
+
+format_version() {
+    ver="$1"
+    case "$ver" in
+        *.*)
+            echo "$ver"
+            ;;
+        *)
+            echo "0.0.0-$ver"
+            ;;
+    esac
+}
+
+if [ -n "$VERSION_FROM_GIT" ]; then
+    format_version "$VERSION_FROM_GIT"
+    exit 0
+fi
+
+if [ "$VERSION_FROM_ARCHIVE" != '$Format:%H$' ]; then
+    short_hash=$(echo "$VERSION_FROM_ARCHIVE" | cut -c1-7)
+    format_version "$short_hash"
+    exit 0
+fi
+
+echo "ERROR: Version detection failed." >&2
+exit 2
+SCRIPT
+
+output=$(sh getversion_archive.sh)
+check_exact "Archive fallback -> 0.0.0-abc1234" "0.0.0-abc1234" "$output"
+
+# ===========================================
+# Test 21: Empty repository (no commits)
+# ===========================================
+log_info "Empty repository (no commits)"
+cd "$TEST_DIR"
+mkdir -p test21_empty
+cd test21_empty
+git init -q
+cp "$TEST_DIR/getversion.sh" .
+
+output=$(sh ./getversion.sh 2>&1) || true
+# git describe fails on empty repo
+if echo "$output" | grep -q "ERROR"; then
+    log_pass "Empty repo returns error"
+else
+    log_fail "Empty repo returns error" "ERROR message" "$output"
+fi
+
+# ===========================================
+# Test 22: Tag not matching semver (custom format)
+# ===========================================
+log_info "Non-semver tag with dots"
+cd "$TEST_DIR"
+mkdir -p test22_custom_tag
+cd test22_custom_tag
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+git config commit.gpgsign false
+echo "content" > file.txt
+git add file.txt
+git commit -q -m "Initial commit"
+git tag "release.2024.01"
+cp "$TEST_DIR/getversion.sh" .
+
+output=$(run_getversion)
+check_exact "Custom tag with dots -> release.2024.01" "release.2024.01" "$output"
+
+# ===========================================
+# Summary
+# ===========================================
+echo ""
+echo "=========================================="
+echo "Test Summary"
+echo "=========================================="
+printf "${GREEN}Passed${NC}: %d\n" "$PASS"
+printf "${RED}Failed${NC}: %d\n" "$FAIL"
+echo "=========================================="
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+
+exit 0

--- a/build-utils/getversion.sh
+++ b/build-utils/getversion.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 # Get the current version using various methods.
-
+#
+# Output format examples:
+#   No tags:        0.0.0-306393a or 0.0.0-306393a-dirty
+#   With tag:       1.0.0 or 1.0.0-dirty
+#   Tag + commits:  1.0.0-17-gfc5d7f2 or 1.0.0-17-gfc5d7f2-dirty
+#
 # The following will serve as a fallback version string (which is the short
 # hash of the latest commit before the application was packaged (if it was
 # packaged)). You will find that this file is listed inside the .gitattributes
@@ -10,34 +15,44 @@
 #
 # This tells git to replace the format string in the following line with the
 # current hash upon the calling of the `git archive <hash/tag>` command.
-VERSION_FROM_ARCHIVE=$Format:%H$
+VERSION_FROM_ARCHIVE='$Format:%H$'
 
-# The preferred method is to use the git describe command but this is only
-# possible if the .git directory is present.
-if [ -d .git -a -r .git ]
+# Check if we have a git repository (directory or worktree file)
+if [ -d .git ] || { [ -f .git ] && grep -q '^gitdir:' .git 2>/dev/null; }
 then
-    VERSION_FROM_GIT=`git describe --tags --always`
+    VERSION_FROM_GIT=$(git describe --tags --always --dirty 2>/dev/null)
 fi
 
-# In case of a worktree checkout, there is not .git directory, but a
-# .git file, which contains the path to the branch information within
-# the git repository. In this case, "git describe" works too.
-if [ -f .git -a -r .git ] && grep -q ^gitdir .git
-then
-    VERSION_FROM_GIT=`git describe --tags --always`
+# Format version: prepend 0.0.0- if no tag (output is just hash with optional -dirty)
+# Version tags contain dots (e.g., 1.0.0), commit hashes don't (e.g., 306393a)
+format_version() {
+    ver="$1"
+    case "$ver" in
+        *.*)
+            # Contains a dot - has a version tag
+            echo "$ver"
+            ;;
+        *)
+            # No dot - just commit hash (possibly with -dirty suffix)
+            echo "0.0.0-$ver"
+            ;;
+    esac
+}
+
+if [ -n "$VERSION_FROM_GIT" ]; then
+    format_version "$VERSION_FROM_GIT"
+    exit 0
 fi
 
-if [ x"$VERSION_FROM_GIT" != x ]; then
-    echo $VERSION_FROM_GIT; exit 0;
+# Fallback: version from git archive substitution
+if [ "$VERSION_FROM_ARCHIVE" != '$Format:%H$' ]; then
+    # Use short hash (first 7 characters)
+    short_hash=$(echo "$VERSION_FROM_ARCHIVE" | cut -c1-7)
+    format_version "$short_hash"
+    exit 0
 fi
 
-if [ "$VERSION_FROM_ARCHIVE" != ':%H$' ]; then
-    echo $VERSION_FROM_ARCHIVE | cut -b1-8; exit 0;
-fi
-
-echo "ERROR: Git commit hash detection failed: Please check why "
-     "build-utils/getversion.sh is failing in your setup and get in touch with us." >&2
-
+echo "ERROR: Version detection failed. Not a git repo and no archive hash." >&2
 exit 2
 
 # vim: ft=sh:et:sw=4:ts=8:sts=4:tw=80

--- a/common/luaobject.c
+++ b/common/luaobject.c
@@ -172,10 +172,6 @@ luaH_object_remove_signal(lua_State *L, gint oud,
         const gchar *name, gint ud) {
     luaH_checkfunction(L, ud);
     lua_object_t *obj = lua_touserdata(L, oud);
-    if (!obj) {
-        warn("object remove signal on non object");
-        return;
-    }
     gpointer ref = (gpointer) lua_topointer(L, ud);
     signal_remove(obj->signals, name, ref);
     luaH_object_unref_item(L, oud, ref);

--- a/common/luaserialize.c
+++ b/common/luaserialize.c
@@ -95,10 +95,6 @@ lua_serialize_value(lua_State *L, GByteArray *out, int index)
         }
         case LUA_TLIGHTUSERDATA: {
             gpointer p = lua_touserdata(L, index);
-            if (!p) {
-                warn("serialize lua lightuserdata on non object");
-                break;
-            }
             g_byte_array_append(out, (guint8*)&p, sizeof(p));
             break;
         }

--- a/doc/luadoc/dom_element.lua
+++ b/doc/luadoc/dom_element.lua
@@ -71,8 +71,9 @@
 -- @readonly
 
 --- @property value
--- The "value" attribute of the element.
--- @type string
+-- The "value" attribute of the element. Integer for `<li>` elements, string
+-- otherwise.
+-- @type integer|string
 -- @readwrite
 
 --- @property checked

--- a/extension/clib/dom_document.c
+++ b/extension/clib/dom_document.c
@@ -53,13 +53,14 @@ webkit_dom_document_destroy_cb(dom_document_t *document, GObject *doc)
 }
 
 gint
-luaH_dom_document_from_webkit_dom_document(lua_State *L, WebKitDOMDocument *doc)
+luaH_dom_document_from_webkit_dom_document(lua_State *L, WebKitDOMDocument *doc, WebKitWebPage *page)
 {
     if (luaH_uniq_get_ptr(L, REG_KEY, doc))
         return 1;
 
     dom_document_t *document = dom_document_new(L);
     document->document = doc;
+    document->page = page;
 
     luaH_uniq_add_ptr(L, REG_KEY, doc, -1);
     g_object_weak_ref(G_OBJECT(doc), (GWeakNotify)webkit_dom_document_destroy_cb, document);
@@ -77,7 +78,7 @@ static gint
 luaH_dom_document_push_body(lua_State *L, dom_document_t *document)
 {
     WebKitDOMHTMLElement* node = webkit_dom_document_get_body(document->document);
-    return luaH_dom_element_from_node(L, WEBKIT_DOM_ELEMENT(node));
+    return luaH_dom_element_from_node(L, WEBKIT_DOM_ELEMENT(node), document->page);
 }
 
 static gint
@@ -147,7 +148,7 @@ luaH_dom_document_create_element(lua_State *L)
         webkit_dom_html_element_set_inner_text(WEBKIT_DOM_HTML_ELEMENT(elem), inner_text, NULL);
     }
 
-    return luaH_dom_element_from_node(L, elem);
+    return luaH_dom_element_from_node(L, elem, document->page);
 }
 
 static gint
@@ -159,7 +160,7 @@ luaH_dom_document_element_from_point(lua_State *L)
 
     WebKitDOMElement *elem = webkit_dom_document_element_from_point(document->document, x, y);
 
-    return luaH_dom_element_from_node(L, elem);
+    return luaH_dom_element_from_node(L, elem, document->page);
 }
 
 static gint

--- a/extension/clib/dom_document.h
+++ b/extension/clib/dom_document.h
@@ -30,10 +30,11 @@
 typedef struct _dom_document_t {
     LUA_OBJECT_HEADER
     WebKitDOMDocument *document;
+    WebKitWebPage *page;
 } dom_document_t;
 
 void dom_document_class_setup(lua_State *);
-gint luaH_dom_document_from_webkit_dom_document(lua_State *L, WebKitDOMDocument *doc);
+gint luaH_dom_document_from_webkit_dom_document(lua_State *L, WebKitDOMDocument *doc, WebKitWebPage *page);
 
 #endif
 

--- a/extension/clib/dom_element.c
+++ b/extension/clib/dom_element.c
@@ -24,6 +24,7 @@
 
 #include "extension/clib/dom_element.h"
 #include "extension/clib/dom_document.h"
+#include "common/luajs.h"
 #include "common/luauniq.h"
 #include "extension/extension.h"
 
@@ -32,6 +33,8 @@
 static lua_class_t dom_element_class;
 
 LUA_DOM_ELEMENT_FUNCS(dom_element_class, dom_element_t, dom_element);
+
+#define L_DOM_ELEMENT_TO_JSC_VALUE(e) webkit_frame_get_js_value_for_dom_object(webkit_web_page_get_main_frame(e->page), WEBKIT_DOM_OBJECT(e->element))
 
 static dom_element_t*
 luaH_check_dom_element(lua_State *L, gint udx)
@@ -136,23 +139,30 @@ static gint
 luaH_dom_element_query(lua_State *L)
 {
     dom_element_t *element = luaH_check_dom_element(L, 1);
-    WebKitDOMElement *elem = element->element;
     const char *query = luaL_checkstring(L, 2);
-    GError *error = NULL;
 
-    WebKitDOMNodeList *nodes = webkit_dom_element_query_selector_all(elem, query, &error);
+    JSCValue *ref = L_DOM_ELEMENT_TO_JSC_VALUE(element);
 
-    if (error)
-        return luaL_error(L, "query error: %s", error->message);
+    JSCValue *node_list = jsc_value_object_invoke_method(ref, "querySelectorAll", G_TYPE_STRING, query, G_TYPE_NONE);
+    JSCException *e = jsc_context_get_exception(jsc_value_get_context(ref));
+    if (e) {
+        g_object_unref(node_list);
+        return luaL_error(L, "query error: %s", jsc_exception_to_string(e));
+    }
 
-    gulong n = webkit_dom_node_list_get_length(nodes);
+    JSCValue *length = jsc_value_object_get_property(node_list, "length");
+    int n = jsc_value_to_int32(length);
+    g_object_unref(length);
 
     lua_createtable(L, n, 0);
     for (gulong i=0; i<n; i++) {
-        WebKitDOMNode *node = webkit_dom_node_list_item(nodes, i);
-        luaH_dom_element_from_node(L, WEBKIT_DOM_ELEMENT(node), element->page);
+        JSCValue *node = jsc_value_object_get_property_at_index(node_list, i);
+        luaH_dom_element_from_node(L, WEBKIT_DOM_ELEMENT(webkit_dom_node_for_js_value(node)), element->page);
+        g_object_unref(node);
         lua_rawseti(L, 3, i+1);
     }
+
+    g_object_unref(node_list);
 
     return 1;
 }
@@ -162,36 +172,50 @@ luaH_dom_element_append(lua_State *L)
 {
     dom_element_t *parent = luaH_check_dom_element(L, 1),
                   *child = luaH_check_dom_element(L, 2);
-    WebKitDOMNode *p = WEBKIT_DOM_NODE(parent->element),
-                  *c = WEBKIT_DOM_NODE(child->element);
-    GError *error = NULL;
-    webkit_dom_node_append_child(p, c, &error);
-    return error ? luaL_error(L, "append element error: %s", error->message) : 0;
+    JSCValue *ref = L_DOM_ELEMENT_TO_JSC_VALUE(parent);
+
+    g_object_unref(jsc_value_object_invoke_method(ref, "appendChild", JSC_TYPE_VALUE, L_DOM_ELEMENT_TO_JSC_VALUE(child), G_TYPE_NONE));
+
+    JSCException *e = jsc_context_get_exception(jsc_value_get_context(ref));
+    return e ? luaL_error(L, "append element error: %s", jsc_exception_to_string(e)) : 0;
 }
 
 static gint
 luaH_dom_element_remove(lua_State *L)
 {
     dom_element_t *element = luaH_checkudata(L, 1, &dom_element_class);
-    if (!WEBKIT_DOM_IS_ELEMENT(element->element))
+    JSCValue *ref = L_DOM_ELEMENT_TO_JSC_VALUE(element);
+    if (!jsc_value_object_is_instance_of(ref, "Element"))
         return 0;
-    GError *error = NULL;
-    webkit_dom_element_remove(element->element, &error);
-    return error ? luaL_error(L, "remove element error: %s", error->message) : 0;
+    g_object_unref(jsc_value_object_invoke_method(ref, "remove", G_TYPE_NONE));
+    JSCException *e = jsc_context_get_exception(jsc_value_get_context(ref));
+    return e ? luaL_error(L, "remove element error: %s", jsc_exception_to_string(e)) : 0;
 }
 
 static void
-dom_element_get_left_and_top(WebKitDOMElement *elem, glong *l, glong *t)
+dom_element_get_left_and_top(JSCValue *elem, glong *l, glong *t)
 {
-    if (!elem) {
+    if (!elem || !jsc_value_object_is_instance_of(elem, "Element")) {
         *l = 0;
         *t = 0;
     } else {
-        dom_element_get_left_and_top(webkit_dom_element_get_offset_parent(elem), l, t);
-        *l += webkit_dom_element_get_offset_left(elem);
-        *l -= webkit_dom_element_get_scroll_left(elem);
-        *t += webkit_dom_element_get_offset_top(elem);
-        *t -= webkit_dom_element_get_scroll_top(elem);
+        JSCValue *offset_parent = jsc_value_object_get_property(elem, "offsetParent");
+        dom_element_get_left_and_top(offset_parent, l, t);
+        g_object_unref(offset_parent);
+
+        JSCValue *ret;
+        ret = jsc_value_object_get_property(elem, "offsetLeft");
+        *l += jsc_value_to_int32(ret);
+        g_object_unref(ret);
+        ret = jsc_value_object_get_property(elem, "scrollLeft");
+        *l -= jsc_value_to_int32(ret);
+        g_object_unref(ret);
+        ret = jsc_value_object_get_property(elem, "offsetTop");
+        *t += jsc_value_to_int32(ret);
+        g_object_unref(ret);
+        ret = jsc_value_object_get_property(elem, "scrollTop");
+        *t -= jsc_value_to_int32(ret);
+        g_object_unref(ret);
     }
 }
 
@@ -202,16 +226,26 @@ luaH_dom_element_rect_index(lua_State *L)
     const gchar *prop = luaL_checkstring(L, 2);
     luakit_token_t token = l_tokenize(prop);
 
-    WebKitDOMElement *elem = element->element;
-
     glong left, top;
 
+    JSCValue *ref = L_DOM_ELEMENT_TO_JSC_VALUE(element);
+
     switch (token) {
-        PI_CASE(WIDTH, webkit_dom_element_get_offset_width(elem));
-        PI_CASE(HEIGHT, webkit_dom_element_get_offset_height(elem));
+        case L_TK_WIDTH:
+            JSCValue *offsetWidth = jsc_value_object_get_property(ref, "offsetWidth");
+            int offset_width = jsc_value_to_int32(offsetWidth);
+            g_object_unref(offsetWidth);
+            lua_pushinteger(L, offset_width);
+            return 1;
+        case L_TK_HEIGHT:
+            JSCValue *offsetHeight = jsc_value_object_get_property(ref, "offsetHeight");
+            int offset_height = jsc_value_to_int32(offsetHeight);
+            g_object_unref(offsetHeight);
+            lua_pushinteger(L, offset_height);
+            return 1;
         case L_TK_LEFT:
         case L_TK_TOP:
-            dom_element_get_left_and_top(elem, &left, &top);
+            dom_element_get_left_and_top(ref, &left, &top);
             lua_pushinteger(L, token == L_TK_LEFT ? left : top);
             return 1;
         default:
@@ -311,17 +345,7 @@ static gint
 luaH_dom_element_click(lua_State *L)
 {
     dom_element_t *element = luaH_check_dom_element(L, 1);
-    WebKitDOMElement *elem = element->element;
-    WebKitDOMDocument *doc = webkit_dom_node_get_owner_document(WEBKIT_DOM_NODE(elem));
-    WebKitDOMEventTarget *target = WEBKIT_DOM_EVENT_TARGET(element->element);
-    GError *error = NULL;
-    WebKitDOMEvent *event = webkit_dom_document_create_event(doc, "MouseEvent", &error);
-    if (error)
-        return luaL_error(L, "create event error: %s", error->message);
-    webkit_dom_event_init_event(event, "click", TRUE, TRUE);
-    webkit_dom_event_target_dispatch_event(target, event, &error);
-    if (error)
-        return luaL_error(L, "dispatch event error: %s", error->message);
+    g_object_unref(jsc_value_object_invoke_method(L_DOM_ELEMENT_TO_JSC_VALUE(element), "click", G_TYPE_NONE));
     return 0;
 }
 
@@ -329,7 +353,7 @@ static gint
 luaH_dom_element_focus(lua_State *L)
 {
     dom_element_t *element = luaH_check_dom_element(L, 1);
-    webkit_dom_element_focus(element->element);
+    g_object_unref(jsc_value_object_invoke_method(L_DOM_ELEMENT_TO_JSC_VALUE(element), "focus", G_TYPE_NONE));
     return 0;
 }
 
@@ -337,7 +361,7 @@ static gint
 luaH_dom_element_submit(lua_State *L)
 {
     dom_element_t *element = luaH_check_dom_element(L, 1);
-    webkit_dom_html_form_element_submit(WEBKIT_DOM_HTML_FORM_ELEMENT(element->element));
+    g_object_unref(jsc_value_object_invoke_method(L_DOM_ELEMENT_TO_JSC_VALUE(element), "submit", G_TYPE_NONE));
     return 0;
 }
 
@@ -653,73 +677,13 @@ luaH_dom_element_client_rects(lua_State *L)
 }
 #endif
 
-static gint
-luaH_dom_element_push_src(lua_State *L)
+static int luaH_dom_element_push_attribute(lua_State *L, char *attribute)
 {
-    dom_element_t *element = luaH_check_dom_element(L, 1);
-
-#define CHECK(lower, upper) \
-    if (WEBKIT_DOM_IS_HTML_##upper##_ELEMENT(element->element)) { \
-        lua_pushstring(L, webkit_dom_html_##lower##_element_get_src(WEBKIT_DOM_HTML_##upper##_ELEMENT(element->element))); \
-        return 1; \
-    }
-
-    CHECK(input, INPUT);
-    CHECK(frame, FRAME);
-    CHECK(iframe, IFRAME);
-    CHECK(embed, EMBED);
-    CHECK(image, IMAGE);
-    CHECK(script, SCRIPT);
-
-#undef CHECK
-
-    return 0;
-}
-
-static gint
-luaH_dom_element_push_href(lua_State *L)
-{
-    dom_element_t *element = luaH_check_dom_element(L, 1);
-
-#define CHECK(lower, upper) \
-    if (WEBKIT_DOM_IS_##upper(element->element)) { \
-        lua_pushstring(L, webkit_dom_##lower##_get_href(WEBKIT_DOM_##upper(element->element))); \
-        return 1; \
-    }
-
-    CHECK(html_anchor_element, HTML_ANCHOR_ELEMENT);
-    CHECK(html_area_element, HTML_AREA_ELEMENT);
-    CHECK(html_link_element, HTML_LINK_ELEMENT);
-    CHECK(style_sheet, STYLE_SHEET);
-
-#undef CHECK
-
-    return 0;
-}
-
-static gint
-luaH_dom_element_push_value(lua_State *L)
-{
-    dom_element_t *element = luaH_check_dom_element(L, 1);
-
-#define CHECK(lower, upper, type) \
-    if (WEBKIT_DOM_IS_HTML_##upper##_ELEMENT(element->element)) { \
-        lua_push##type(L, webkit_dom_html_##lower##_element_get_value( \
-                    WEBKIT_DOM_HTML_##upper##_ELEMENT(element->element))); \
-        return 1; \
-    }
-
-    CHECK(text_area, TEXT_AREA, string);
-    CHECK(input, INPUT, string);
-    CHECK(option, OPTION, string);
-    CHECK(param, PARAM, string);
-    CHECK(li, LI, integer);
-    CHECK(button, BUTTON, string);
-    CHECK(select, SELECT, string);
-
-#undef CHECK
-
-    return 0;
+    dom_element_t *elem = luaH_check_dom_element(L, 1);
+    JSCValue *value = jsc_value_object_invoke_method(L_DOM_ELEMENT_TO_JSC_VALUE(elem), "getAttribute", G_TYPE_STRING, attribute, G_TYPE_NONE);
+    int ret = luajs_pushvalue(L, value);
+    g_object_unref(value);
+    return ret;
 }
 
 static gint
@@ -747,48 +711,23 @@ dom_html_element_set_value(lua_State *L, WebKitDOMHTMLElement *element)
     return 0;
 }
 
-static gint
-luaH_dom_element_push_parent(lua_State *L)
+/*
+ * Pushes the element corresponding to the named property of the DOM element on
+ * the stack onto the stack. If the original element has no such property, nil
+ * is pushed instead.
+ */
+static int luaH_dom_element_push_element(lua_State *L, const char *property)
 {
     dom_element_t *element = luaH_check_dom_element(L, 1);
-    WebKitDOMNode *parent = webkit_dom_node_get_parent_node(WEBKIT_DOM_NODE(element->element));
-    return luaH_dom_element_from_node(L, WEBKIT_DOM_ELEMENT(parent), element->page);
-}
-
-static gint
-luaH_dom_element_push_first_child(lua_State *L)
-{
-    dom_element_t *element = luaH_check_dom_element(L, 1);
-    WebKitDOMElement *elem = element->element;
-    WebKitDOMElement *child = webkit_dom_element_get_first_element_child(elem);
-    return luaH_dom_element_from_node(L, child, element->page);
-}
-
-static gint
-luaH_dom_element_push_last_child(lua_State *L)
-{
-    dom_element_t *element = luaH_check_dom_element(L, 1);
-    WebKitDOMElement *elem = element->element;
-    WebKitDOMElement *child = webkit_dom_element_get_last_element_child(elem);
-    return luaH_dom_element_from_node(L, child, element->page);
-}
-
-static gint
-luaH_dom_element_push_prev_sibling(lua_State *L)
-{
-    dom_element_t *element = luaH_check_dom_element(L, 1);
-    WebKitDOMElement *elem = element->element;
-    WebKitDOMElement *child = webkit_dom_element_get_previous_element_sibling(elem);
-    return luaH_dom_element_from_node(L, child, element->page);
-}
-
-static gint
-luaH_dom_element_push_next_sibling(lua_State *L)
-{
-    dom_element_t *element = luaH_check_dom_element(L, 1);
-    WebKitDOMElement *elem = element->element;
-    WebKitDOMElement *child = webkit_dom_element_get_next_element_sibling(elem);
-    return luaH_dom_element_from_node(L, child, element->page);
+    JSCValue *e = jsc_value_object_get_property(L_DOM_ELEMENT_TO_JSC_VALUE(element), property);
+    if (jsc_value_is_null(e)) {
+        g_object_unref(e);
+        lua_pushnil(L);
+        return 1;
+    }
+    int ret = luaH_dom_element_from_node(L, WEBKIT_DOM_ELEMENT(webkit_dom_node_for_js_value(e)), element->page);
+    g_object_unref(e);
+    return ret;
 }
 
 static gint
@@ -813,8 +752,19 @@ static gint
 luaH_dom_element_push_owner_document(lua_State *L)
 {
     dom_element_t *element = luaH_check_dom_element(L, 1);
-    WebKitDOMDocument *doc = webkit_dom_node_get_owner_document(WEBKIT_DOM_NODE(element->element));
-    return luaH_dom_document_from_webkit_dom_document(L, doc, element->page);
+    JSCValue *doc = jsc_value_object_get_property(L_DOM_ELEMENT_TO_JSC_VALUE(element), "ownerDocument");
+    int ret = luaH_dom_document_from_webkit_dom_document(L, WEBKIT_DOM_DOCUMENT(webkit_dom_node_for_js_value(doc)), element->page);
+    g_object_unref(doc);
+    return ret;
+}
+
+static int luaH_dom_element_push_property(lua_State *L, const char *property)
+{
+    dom_element_t *element = luaH_check_dom_element(L, 1);
+    JSCValue *value = jsc_value_object_get_property(L_DOM_ELEMENT_TO_JSC_VALUE(element), property);
+    int ret = luajs_pushvalue(L, value);
+    g_object_unref(value);
+    return ret;
 }
 
 static gint
@@ -827,12 +777,13 @@ luaH_dom_element_index(lua_State *L)
     const char *prop = luaL_checkstring(L, 2);
     luakit_token_t token = l_tokenize(prop);
 
-    WebKitDOMElement *elem = element->element;
-
     switch(token) {
-        PS_CASE(TAG_NAME, webkit_dom_element_get_tag_name(elem))
-        PS_CASE(TEXT_CONTENT, webkit_dom_node_get_text_content(WEBKIT_DOM_NODE(elem)))
-        PS_CASE(INNER_HTML, webkit_dom_element_get_inner_html(elem))
+        case L_TK_TAG_NAME:
+            return luaH_dom_element_push_property(L, "tagName");
+        case L_TK_TEXT_CONTENT:
+            return luaH_dom_element_push_property(L, "textContent");
+        case L_TK_INNER_HTML:
+            return luaH_dom_element_push_property(L, "innerHTML");
 
         PF_CASE(QUERY, luaH_dom_element_query)
         PF_CASE(APPEND, luaH_dom_element_append)
@@ -846,24 +797,46 @@ luaH_dom_element_index(lua_State *L)
         PF_CASE(CLIENT_RECTS, luaH_dom_element_client_rects)
 #endif
 
-        PI_CASE(CHILD_COUNT, webkit_dom_element_get_child_element_count(elem))
+        case L_TK_CHILD_COUNT:
+            return luaH_dom_element_push_property(L, "childElementCount");
 
-        case L_TK_SRC: return luaH_dom_element_push_src(L);
-        case L_TK_HREF: return luaH_dom_element_push_href(L);
-        case L_TK_VALUE: return luaH_dom_element_push_value(L);
-        case L_TK_CHECKED: return webkit_dom_html_input_element_get_checked(
-                                   WEBKIT_DOM_HTML_INPUT_ELEMENT(elem));
-        case L_TK_TYPE: {
-            gchar *type;
-            g_object_get(element->element, "type", &type, NULL);
-            lua_pushstring(L, type);
-            return 1;
-        }
-        case L_TK_PARENT: return luaH_dom_element_push_parent(L);
-        case L_TK_FIRST_CHILD: return luaH_dom_element_push_first_child(L);
-        case L_TK_LAST_CHILD: return luaH_dom_element_push_last_child(L);
-        case L_TK_PREV_SIBLING: return luaH_dom_element_push_prev_sibling(L);
-        case L_TK_NEXT_SIBLING: return luaH_dom_element_push_next_sibling(L);
+        case L_TK_SRC:
+            /*
+             * Returning src as a property rather than attribute for backwards
+             * compatibility, despite it being documented as an attribute. The
+             * difference is that as an attribute, relative URLs will remain
+             * relative whereas like this the complete URI is obtained.
+             */
+            return luaH_dom_element_push_property(L, "src");
+        case L_TK_HREF:
+            /*
+             * Returning href as a property rather than attribute for backwards
+             * compatibility, despite it being documented as an attribute. The
+             * difference is that as an attribute, relative URLs will remain
+             * relative whereas like this the complete URI is obtained.
+             */
+            return luaH_dom_element_push_property(L, "href");
+        case L_TK_VALUE:
+            /*
+             * Handle value as a property to automatically get integer
+             * conversion for <li> elements which is necessary to maintain
+             * backwards compatibility.
+             */
+            return luaH_dom_element_push_property(L, "value");
+        case L_TK_CHECKED:
+            return luaH_dom_element_push_property(L, "checked");
+        case L_TK_TYPE:
+            return luaH_dom_element_push_attribute(L, "type");
+        case L_TK_PARENT:
+            return luaH_dom_element_push_element(L, "parentElement");
+        case L_TK_FIRST_CHILD:
+            return luaH_dom_element_push_element(L, "firstElementChild");
+        case L_TK_LAST_CHILD:
+            return luaH_dom_element_push_element(L, "lastElementChild");
+        case L_TK_PREV_SIBLING:
+            return luaH_dom_element_push_element(L, "previousElementSibling");
+        case L_TK_NEXT_SIBLING:
+            return luaH_dom_element_push_element(L, "nextElementSibling");
         case L_TK_RECT: return luaH_dom_element_push_rect_table(L);
         case L_TK_ATTR: return luaH_dom_element_push_attribute_table(L);
         case L_TK_STYLE: return luaH_dom_element_push_style_table(L);

--- a/extension/clib/dom_element.c
+++ b/extension/clib/dom_element.c
@@ -274,9 +274,10 @@ luaH_dom_element_attribute_index(lua_State *L)
 {
     dom_element_t *element = luaH_check_dom_element(L, lua_upvalueindex(1));
     const gchar *name = luaL_checkstring(L, 2);
-    const gchar *attr = webkit_dom_element_get_attribute(element->element, name);
-    lua_pushstring(L, attr);
-    return 1;
+    JSCValue *attribute = jsc_value_object_invoke_method(L_DOM_ELEMENT_TO_JSC_VALUE(element), "getAttribute", G_TYPE_STRING, name, G_TYPE_NONE);
+    int ret = luajs_pushvalue(L, attribute);
+    g_object_unref(attribute);
+    return ret;
 }
 
 static gint
@@ -285,9 +286,10 @@ luaH_dom_element_attribute_newindex(lua_State *L)
     dom_element_t *element = luaH_check_dom_element(L, lua_upvalueindex(1));
     const gchar *attr = luaL_checkstring(L, 2);
     const gchar *value = luaL_checkstring(L, 3);
-    GError *error = NULL;
-    webkit_dom_element_set_attribute(element->element, attr, value, &error);
-    return error ? luaL_error(L, "attribute error: %s", error->message) : 0;
+    JSCValue *ref = L_DOM_ELEMENT_TO_JSC_VALUE(element);
+    g_object_unref(jsc_value_object_invoke_method(ref, "setAttribute", G_TYPE_STRING, attr, G_TYPE_STRING, value, G_TYPE_NONE));
+    JSCException *e = jsc_context_get_exception(jsc_value_get_context(ref));
+    return e ? luaL_error(L, "attribute error: %s", jsc_exception_to_string(e)) : 0;
 }
 
 static gint

--- a/extension/clib/dom_element.c
+++ b/extension/clib/dom_element.c
@@ -686,31 +686,6 @@ static int luaH_dom_element_push_attribute(lua_State *L, char *attribute)
     return ret;
 }
 
-static gint
-dom_html_element_set_value(lua_State *L, WebKitDOMHTMLElement *element)
-{
-
-#define CHECK(lower, upper, type) \
-    if (WEBKIT_DOM_IS_HTML_##upper##_ELEMENT(element)) { \
-        webkit_dom_html_##lower##_element_set_value( \
-                WEBKIT_DOM_HTML_##upper##_ELEMENT(element), \
-                luaL_check##type(L, 3)); \
-        return 1; \
-    }
-
-    CHECK(text_area, TEXT_AREA, string);
-    CHECK(input, INPUT, string);
-    CHECK(option, OPTION, string);
-    CHECK(param, PARAM, string);
-    CHECK(li, LI, integer);
-    CHECK(button, BUTTON, string);
-    CHECK(select, SELECT, string);
-
-#undef CHECK
-
-    return 0;
-}
-
 /*
  * Pushes the element corresponding to the named property of the DOM element on
  * the stack onto the stack. If the original element has no such property, nil
@@ -854,27 +829,29 @@ luaH_dom_element_newindex(lua_State *L)
     const char *prop = luaL_checkstring(L, 2);
     luakit_token_t token = l_tokenize(prop);
 
-    GError *error = NULL;
-
+    char *name;
     switch (token) {
         case L_TK_INNER_HTML:
-            webkit_dom_element_set_inner_html(element->element,
-                    luaL_checkstring(L, 3), &error);
-            if (error)
-                return luaL_error(L, "set inner html error: %s", error->message);
+            name = "innerHTML";
             break;
         case L_TK_VALUE:
-            if (!dom_html_element_set_value(L, WEBKIT_DOM_HTML_ELEMENT(element->element)))
-                return luaL_error(L, "set value error: wrong element type");
+            name = "value";
             break;
         case L_TK_CHECKED:
-            webkit_dom_html_input_element_set_checked(
-                    WEBKIT_DOM_HTML_INPUT_ELEMENT(element->element),
-                    lua_toboolean(L, 3));
+            name = "checked";
             break;
         default:
             return 0;
     }
+
+    JSCValue *ref = L_DOM_ELEMENT_TO_JSC_VALUE(element);
+
+    JSCValue *value = luajs_tovalue(L, 3, jsc_value_get_context(ref));
+    if (!value)
+        return luaL_error(L, "failed to convert the Lua value to JavaScript");
+
+    jsc_value_object_set_property(ref, name, value);
+    g_object_unref(value);
 
     return luaH_object_property_signal(L, 1, token);
 }

--- a/extension/clib/dom_element.c
+++ b/extension/clib/dom_element.c
@@ -26,6 +26,7 @@
 #include "extension/clib/dom_document.h"
 #include "common/luajs.h"
 #include "common/luauniq.h"
+#include "common/util.h"
 #include "extension/extension.h"
 
 #define REG_KEY "luakit.uniq.registry.dom_element"
@@ -657,34 +658,35 @@ luaH_dom_element_remove_event_listener(lua_State *L)
     return 1;
 }
 
-#if WEBKIT_CHECK_VERSION(2,18,0)
 static gint
 luaH_dom_element_client_rects(lua_State *L)
 {
     dom_element_t *element = luaH_check_dom_element(L, 1);
-    WebKitDOMClientRectList *rects = webkit_dom_element_get_client_rects(element->element);
-    int num_rects = webkit_dom_client_rect_list_get_length(rects);
+    JSCValue *rects = jsc_value_object_invoke_method(L_DOM_ELEMENT_TO_JSC_VALUE(element), "getClientRects", G_TYPE_NONE);
+
+    JSCValue *length = jsc_value_object_get_property(rects, "length");
+    int num_rects = jsc_value_to_int32(length);
+    g_object_unref(length);
 
     lua_createtable(L, num_rects, 0);
     for (int i = 0; i < num_rects; ++i) {
-        WebKitDOMClientRect* rect = webkit_dom_client_rect_list_item(rects, i);
+        JSCValue *rect = jsc_value_object_get_property_at_index(rects, i);
         lua_newtable(L);
-#define PROP(prop) \
-            lua_pushnumber(L, webkit_dom_client_rect_get_##prop(rect)); \
-            lua_setfield(L, -2, #prop);
-        PROP(top)
-        PROP(right)
-        PROP(bottom)
-        PROP(left)
-        PROP(width)
-        PROP(height)
-#undef PROP
+        char *properties[] = {"top", "right", "bottom", "left", "width", "height"};
+        for (int j = 0; j < LENGTH(properties); j++) {
+            JSCValue *property = jsc_value_object_get_property(rect, properties[j]);
+            lua_pushnumber(L, jsc_value_to_int32(property));
+            lua_setfield(L, -2, properties[j]);
+            g_object_unref(property);
+        }
         lua_rawseti(L, -2, i+1);
+        g_object_unref(rect);
     }
+
+    g_object_unref(rects);
 
     return 1;
 }
-#endif
 
 static int luaH_dom_element_push_attribute(lua_State *L, char *attribute)
 {
@@ -777,9 +779,7 @@ luaH_dom_element_index(lua_State *L)
         PF_CASE(SUBMIT, luaH_dom_element_submit)
         PF_CASE(ADD_EVENT_LISTENER, luaH_dom_element_add_event_listener)
         PF_CASE(REMOVE_EVENT_LISTENER, luaH_dom_element_remove_event_listener)
-#if WEBKIT_CHECK_VERSION(2,18,0)
         PF_CASE(CLIENT_RECTS, luaH_dom_element_client_rects)
-#endif
 
         case L_TK_CHILD_COUNT:
             return luaH_dom_element_push_property(L, "childElementCount");

--- a/extension/clib/dom_element.c
+++ b/extension/clib/dom_element.c
@@ -106,7 +106,7 @@ luaH_dom_element_gc(lua_State *L)
 }
 
 gint
-luaH_dom_element_from_node(lua_State *L, WebKitDOMElement* node)
+luaH_dom_element_from_node(lua_State *L, WebKitDOMElement* node, WebKitWebPage *page)
 {
     if (!node) {
         lua_pushnil(L);
@@ -118,6 +118,7 @@ luaH_dom_element_from_node(lua_State *L, WebKitDOMElement* node)
 
     dom_element_t *element = dom_element_new(L);
     element->element = node;
+    element->page = page;
 
     luaH_uniq_add_ptr(L, REG_KEY, node, -1);
     g_object_weak_ref(G_OBJECT(node), (GWeakNotify)webkit_web_page_destroy_cb, element);
@@ -129,63 +130,6 @@ dom_element_t *
 luaH_to_dom_element(lua_State *L, gint idx)
 {
     return luaH_toudata(L, idx, &dom_element_class);
-}
-
-static char *
-dom_element_selector(dom_element_t *element)
-{
-    WebKitDOMNode *elem = WEBKIT_DOM_NODE(element->element), *parent;
-    GPtrArray *parts = g_ptr_array_new_full(10, g_free);
-
-    while ((parent = webkit_dom_node_get_parent_node(elem))) {
-        char *tag = webkit_dom_element_get_tag_name(WEBKIT_DOM_ELEMENT(elem));
-        if (!strcmp(tag, "BODY") || !strcmp(tag, "HEAD")) {
-            g_ptr_array_add(parts, g_strdup(tag));
-            break;
-        } else {
-            int c = 1;
-            WebKitDOMElement *e = WEBKIT_DOM_ELEMENT(elem), *ps;
-            while ((ps = webkit_dom_element_get_previous_element_sibling(e))) {
-                e = ps;
-                c++;
-            }
-            g_ptr_array_add(parts, g_strdup_printf("%s:nth-child(%d)", tag, c));
-        }
-        elem = parent;
-    }
-
-    /* Reverse array and add null terminator for g_strjoinv() */
-    for (guint i = 0, j = parts->len-1; i < j; i++, j--) {
-        char *tmp = parts->pdata[i];
-        parts->pdata[i] = parts->pdata[j];
-        parts->pdata[j] = tmp;
-    }
-    g_ptr_array_add(parts, NULL);
-
-    char *sel = g_strjoinv(" > ", (char **)parts->pdata);
-    g_ptr_array_free(parts, TRUE);
-    return sel;
-}
-
-JSCValue *
-dom_element_js_ref(page_t *page, dom_element_t *element)
-{
-    gchar *sel = dom_element_selector(element);
-
-    WebKitFrame *frame = webkit_web_page_get_main_frame(page->page);
-    WebKitScriptWorld *world = extension.script_world;
-    JSCContext *ctx = webkit_frame_get_js_context_for_script_world(frame, world);
-
-    JSCValue *js_global = jsc_context_get_global_object(ctx);
-    JSCValue *js_doc = jsc_value_object_get_property(js_global, "document");
-    JSCValue *ret = jsc_value_object_invoke_method(js_doc, "querySelector", G_TYPE_STRING, sel, G_TYPE_NONE);
-
-    g_object_unref(js_doc);
-    g_object_unref(js_global);
-    g_object_unref(ctx);
-    g_free(sel);
-
-    return ret;
 }
 
 static gint
@@ -206,7 +150,7 @@ luaH_dom_element_query(lua_State *L)
     lua_createtable(L, n, 0);
     for (gulong i=0; i<n; i++) {
         WebKitDOMNode *node = webkit_dom_node_list_item(nodes, i);
-        luaH_dom_element_from_node(L, WEBKIT_DOM_ELEMENT(node));
+        luaH_dom_element_from_node(L, WEBKIT_DOM_ELEMENT(node), element->page);
         lua_rawseti(L, 3, i+1);
     }
 
@@ -495,7 +439,7 @@ event_listener_cb(WebKitDOMElement *UNUSED(elem), WebKitDOMEvent *event, gboolea
     lua_createtable(L, 0, 1);
     lua_pushliteral(L, "target");
     WebKitDOMEventTarget *target = webkit_dom_event_get_src_element(event);
-    luaH_dom_element_from_node(L, WEBKIT_DOM_ELEMENT(target));
+    luaH_dom_element_from_node(L, WEBKIT_DOM_ELEMENT(target), element->page);
     lua_rawset(L, -3);
 
     lua_pushliteral(L, "type");
@@ -808,7 +752,7 @@ luaH_dom_element_push_parent(lua_State *L)
 {
     dom_element_t *element = luaH_check_dom_element(L, 1);
     WebKitDOMNode *parent = webkit_dom_node_get_parent_node(WEBKIT_DOM_NODE(element->element));
-    return luaH_dom_element_from_node(L, WEBKIT_DOM_ELEMENT(parent));
+    return luaH_dom_element_from_node(L, WEBKIT_DOM_ELEMENT(parent), element->page);
 }
 
 static gint
@@ -817,7 +761,7 @@ luaH_dom_element_push_first_child(lua_State *L)
     dom_element_t *element = luaH_check_dom_element(L, 1);
     WebKitDOMElement *elem = element->element;
     WebKitDOMElement *child = webkit_dom_element_get_first_element_child(elem);
-    return luaH_dom_element_from_node(L, child);
+    return luaH_dom_element_from_node(L, child, element->page);
 }
 
 static gint
@@ -826,7 +770,7 @@ luaH_dom_element_push_last_child(lua_State *L)
     dom_element_t *element = luaH_check_dom_element(L, 1);
     WebKitDOMElement *elem = element->element;
     WebKitDOMElement *child = webkit_dom_element_get_last_element_child(elem);
-    return luaH_dom_element_from_node(L, child);
+    return luaH_dom_element_from_node(L, child, element->page);
 }
 
 static gint
@@ -835,7 +779,7 @@ luaH_dom_element_push_prev_sibling(lua_State *L)
     dom_element_t *element = luaH_check_dom_element(L, 1);
     WebKitDOMElement *elem = element->element;
     WebKitDOMElement *child = webkit_dom_element_get_previous_element_sibling(elem);
-    return luaH_dom_element_from_node(L, child);
+    return luaH_dom_element_from_node(L, child, element->page);
 }
 
 static gint
@@ -844,7 +788,7 @@ luaH_dom_element_push_next_sibling(lua_State *L)
     dom_element_t *element = luaH_check_dom_element(L, 1);
     WebKitDOMElement *elem = element->element;
     WebKitDOMElement *child = webkit_dom_element_get_next_element_sibling(elem);
-    return luaH_dom_element_from_node(L, child);
+    return luaH_dom_element_from_node(L, child, element->page);
 }
 
 static gint
@@ -862,7 +806,7 @@ luaH_dom_element_push_document(lua_State *L)
     } else
         doc = webkit_dom_node_get_owner_document(WEBKIT_DOM_NODE(element->element));
 
-    return luaH_dom_document_from_webkit_dom_document(L, doc);
+    return luaH_dom_document_from_webkit_dom_document(L, doc, element->page);
 }
 
 static gint
@@ -870,7 +814,7 @@ luaH_dom_element_push_owner_document(lua_State *L)
 {
     dom_element_t *element = luaH_check_dom_element(L, 1);
     WebKitDOMDocument *doc = webkit_dom_node_get_owner_document(WEBKIT_DOM_NODE(element->element));
-    return luaH_dom_document_from_webkit_dom_document(L, doc);
+    return luaH_dom_document_from_webkit_dom_document(L, doc, element->page);
 }
 
 static gint

--- a/extension/clib/dom_element.c
+++ b/extension/clib/dom_element.c
@@ -315,13 +315,20 @@ static gint
 luaH_dom_element_style_index(lua_State *L)
 {
     dom_element_t *element = luaH_check_dom_element(L, lua_upvalueindex(1));
-    WebKitDOMDocument *document = webkit_dom_node_get_owner_document(WEBKIT_DOM_NODE(element->element));
-    WebKitDOMDOMWindow *window = webkit_dom_document_get_default_view(document);
-    WebKitDOMCSSStyleDeclaration *style = webkit_dom_dom_window_get_computed_style(window, element->element, "");
+    JSCValue *ref = L_DOM_ELEMENT_TO_JSC_VALUE(element);
+    JSCValue *window = jsc_context_get_value(jsc_value_get_context(ref), "window");
+    JSCValue *computed_style = jsc_value_object_invoke_method(window, "getComputedStyle", JSC_TYPE_VALUE, ref, G_TYPE_NONE);
 
     const gchar *name = luaL_checkstring(L, 2);
-    const gchar *value = webkit_dom_css_style_declaration_get_property_value(style, name);
-    lua_pushstring(L, value);
+    JSCValue *value = jsc_value_object_invoke_method(computed_style, "getPropertyValue", G_TYPE_STRING, name, G_TYPE_NONE);
+    char *s = jsc_value_to_string(value);
+    lua_pushstring(L, s);
+    free(s);
+    g_object_unref(value);
+
+    g_object_unref(computed_style);
+    g_object_unref(window);
+
     return 1;
 }
 

--- a/extension/clib/dom_element.h
+++ b/extension/clib/dom_element.h
@@ -50,11 +50,11 @@ typedef struct _dom_element_t {
     LUA_OBJECT_HEADER
     signal_t *dom_events;
     WebKitDOMElement *element;
+    WebKitWebPage *page;
 } dom_element_t;
 
 void dom_element_class_setup(lua_State *);
-gint luaH_dom_element_from_node(lua_State *L, WebKitDOMElement* node);
-JSCValue *dom_element_js_ref(page_t *page, dom_element_t *element);
+gint luaH_dom_element_from_node(lua_State *L, WebKitDOMElement* node, WebKitWebPage *page);
 dom_element_t * luaH_to_dom_element(lua_State *L, gint idx);
 
 #endif

--- a/extension/clib/page.c
+++ b/extension/clib/page.c
@@ -127,7 +127,6 @@ static gint
 luaH_page_js_func(lua_State *L)
 {
     JSCValue *func = (JSCValue *)lua_topointer(L, lua_upvalueindex(1));
-    page_t *page = luaH_check_page(L, lua_upvalueindex(2));
     JSCContext *ctx = jsc_value_get_context(func);
 
     gint argc = lua_gettop(L);
@@ -138,7 +137,7 @@ luaH_page_js_func(lua_State *L)
          * is defined in common/, which is shared in the main process, and the
          * main process is not aware of the extension/clib/ stuff */
         if (elem)
-            args[i] = dom_element_js_ref(page, elem);
+            args[i] = webkit_frame_get_js_value_for_dom_object(webkit_web_page_get_main_frame(elem->page), WEBKIT_DOM_OBJECT(elem->element));
         else
             args[i] = luajs_tovalue(L, i+1, ctx);
     }
@@ -184,8 +183,7 @@ luaH_page_eval_js(lua_State *L)
 
     if (jsc_value_is_function(res)) {
         lua_pushlightuserdata(L, res);
-        lua_pushvalue(L, 1);
-        lua_pushcclosure(L, luaH_page_js_func, 2);
+        lua_pushcclosure(L, luaH_page_js_func, 1);
         return 1;
     }
 
@@ -274,7 +272,7 @@ static gint
 luaH_page_push_document(lua_State *L, page_t *page)
 {
     WebKitDOMDocument *doc = webkit_web_page_get_dom_document(page->page);
-    return luaH_dom_document_from_webkit_dom_document(L, doc);
+    return luaH_dom_document_from_webkit_dom_document(L, doc, page->page);
 }
 
 static gint

--- a/extension/ipc.c
+++ b/extension/ipc.c
@@ -158,7 +158,14 @@ web_extension_connect(const gchar *socket_path)
     struct sockaddr_un remote;
     memset(&remote, 0, sizeof(remote));
     remote.sun_family = AF_UNIX;
-    strcpy(remote.sun_path, socket_path);
+
+    if (strlen(socket_path) >= sizeof(remote.sun_path)) {
+        g_error("Socket path too long (%zu >= %zu): %s",
+                strlen(socket_path), sizeof(remote.sun_path), socket_path);
+        goto fail_socket;
+    }
+    g_strlcpy(remote.sun_path, socket_path, sizeof(remote.sun_path));
+
     int len = offsetof(struct sockaddr_un, sun_path) + strlen(remote.sun_path);
 
     debug("luakit web process: connecting to %s", socket_path);

--- a/ipc.c
+++ b/ipc.c
@@ -122,7 +122,12 @@ web_extension_connect_thread(gpointer UNUSED(data))
     struct sockaddr_un local;
     memset(&local, 0, sizeof(local));
     local.sun_family = AF_UNIX;
-    strcpy(local.sun_path, path);
+
+    if (strlen(path) >= sizeof(local.sun_path))
+        fatal("Socket path too long (%zu >= %zu): %s",
+              strlen(path), sizeof(local.sun_path), path);
+    g_strlcpy(local.sun_path, path, sizeof(local.sun_path));
+
     int len = offsetof(struct sockaddr_un, sun_path) + strlen(local.sun_path);
 
     /* Remove any pre-existing socket, before opening */

--- a/lib/select_wm.lua
+++ b/lib/select_wm.lua
@@ -14,8 +14,6 @@ local _M = {}
 
 local ui = ipc_channel("select_wm")
 
-local has_client_rects_api = tonumber(luakit.webkit_version:match("^2%.(%d+)%.")) > 16
-
 -- Label making
 
 -- Calculates the minimum number of characters needed in a hint given a
@@ -185,7 +183,7 @@ local function get_element_bb_if_visible(element, wbb, client_rects)
     -- Find the element bounding box
     local r
 
-    if has_client_rects_api and not element.first_child then
+    if not element.first_child then
         r = element:client_rects()
         for i=#r,1,-1 do
             if r[i].width == 0 or r[i].height == 0 then table.remove(r, i) end

--- a/lib/styles.lua
+++ b/lib/styles.lua
@@ -369,7 +369,7 @@ end
 -- = nil` to turn off the watch.
 -- @tparam string path the path of the watched style.
 _M.watch_styles = function (guard, path)
-    luakit.spawn("bash -c 'inotifywait -t 10 \"" .. path .. "\" || sleep 1'", function ()
+    luakit.spawn(string.format("bash -c 'inotifywait -t 10 %q || sleep 1'", path), function ()
         _M.detect_files()
         if guard[1] then _M.watch_styles(guard, path) end
     end)

--- a/tests/async/test_completion.lua
+++ b/tests/async/test_completion.lua
@@ -6,12 +6,15 @@ local T = {}
 local assert = require("luassert")
 
 uris = {"about:blank"}
+
+local test = require("tests.lib")
 require "config.rc"
 
 local window = require "window"
 local w = assert(select(2, next(window.bywidget)))
 
 T.test_leaving_completion_restores_correct_input_text = function ()
+    test.wait_for_idle()
     local input = w.ibar.input
 
     w:enter_cmd(":tab")

--- a/tests/async/test_memory_leaks.lua
+++ b/tests/async/test_memory_leaks.lua
@@ -3,6 +3,8 @@
 -- @copyright 2017 Aidan Holm <aidanholm@gmail.com>
 
 uris = {"about:blank"}
+
+local test = require("tests.lib")
 require "config.rc"
 
 local window = require "window"
@@ -11,6 +13,7 @@ local w = assert(select(2, next(window.bywidget)))
 local T = {}
 
 T.test_webview_from_closed_tab_is_released = function ()
+    test.wait_for_idle()
     local refs = setmetatable({}, { __mode = "k" })
     refs[w.view] = true
     w:close_tab()

--- a/tests/async/test_scroll.lua
+++ b/tests/async/test_scroll.lua
@@ -13,6 +13,7 @@ local window = require "window"
 local w = assert(select(2, next(window.bywidget)))
 
 T.test_scrolling_works = function ()
+    test.wait_for_idle()
     test.wait_for_view(w.view)
 
     -- Fetch height of document body

--- a/tests/async/test_undoclose.lua
+++ b/tests/async/test_undoclose.lua
@@ -15,6 +15,7 @@ local window = require "window"
 local w = assert(select(2, next(window.bywidget)))
 
 T.test_undo_close_restores_tab_history = function ()
+    test.wait_for_idle()
     -- Load page in new tab
     local uri = test.http_server() .. "undoclose_page.html"
     w:new_tab(uri)

--- a/tests/lib.lua
+++ b/tests/lib.lua
@@ -16,6 +16,20 @@ function _M.init(arg)
     shared_lib = arg
 end
 
+--- Pause test execution until the next idle event in the main event loop.
+--
+-- Schedules a one-shot resume callback using `luakit.idle_add()` and
+-- suspends the test coroutine until the event loop is next idle.
+-- This ensures all pending `idle_add` hooks ("post-require" module
+-- initializations) are executed before subsequent test code runs.
+--
+-- Does nothing if called outside of the test context.
+function _M.wait_for_idle()
+    local luakit = require "luakit"
+    luakit.idle_add(_M.continue)
+    _M.wait()
+end
+
 --- Pause test execution until a webview widget finishes loading.
 --
 -- @tparam widget view The webview widget to wait on.

--- a/tests/run_test.lua
+++ b/tests/run_test.lua
@@ -133,6 +133,8 @@ local function spawn_luakit_instance(config, ...)
     if lfs.attributes(gst_dir, "mode") == "directory" then
         os.execute("mkdir -p " .. env.XDG_CACHE_HOME .. "/gstreamer-1.0/")
         os.execute("cp "..gst_dir.."/registry.x86_64.bin " .. env.XDG_CACHE_HOME .. "/gstreamer-1.0")
+        os.execute(string.format("mkdir -p %q", env.XDG_CACHE_HOME .. "/gstreamer-1.0/"))
+        os.execute(string.format("cp %q %q", gst_dir.."/registry.x86_64.bin", env.XDG_CACHE_HOME .. "/gstreamer-1.0"))
     end
 
     -- Build env prefix
@@ -159,7 +161,7 @@ getmetatable(onexit_prx).__gc = cleanup
 table.insert(exit_handlers, function ()
     print("Removing temporary directories")
     for _, dir in ipairs(luakit_tmp_dirs) do
-        os.execute("rm -r " .. dir)
+        os.execute(string.format("rm -r %q", dir))
     end
 end)
 


### PR DESCRIPTION
Thanks to @balejk for the dom element rewrite.

- DOM element (JSC rewrite): __index, __newindex, style, attributes, and client_rects on dom_element are rewritten to use the JavaScriptCore C API instead of the deprecated WebKit DOM bindings. dom_document and dom_element now store a reference to the owning WebKitWebPage, required for JSC access.
- Security hardening: Replace unsafe strcpy() with g_strlcpy() plus length-checked bounds on AF_UNIX socket paths in both ipc.c and extension/ipc.c. Quote shell arguments with %q in styles.lua and run_test.lua to prevent path injection.
- Test reliability: Add wait_for_idle() to the test library to synchronize with luakit's internal idle_add queue before asserting state, fixing races in test_completion, test_memory_leaks, test_scroll, and test_undoclose.
- Bug fix: Remove incorrect lightuserdata check in luaobject.c and luaserialize.c (fixes #1117).
- Build: Rewrite build-utils/getversion.sh with more robust version detection and add a comprehensive test script.