### PR TITLE
Persist per-view zoom level across navigation and reload

### DIFF
--- a/lib/binds.lua
+++ b/lib/binds.lua
@@ -99,6 +99,7 @@ modes.add_binds("all", {
         scroll_acc = scroll_acc + o.dy
         while scroll_acc < -1.0 do scroll_acc = scroll_acc + 1.0 w:zoom_in() end
         while scroll_acc > 1.0 do scroll_acc = scroll_acc - 1.0 w:zoom_out() end
+        settings.override_setting_for_view(w.view, "webview.zoom_level", w.view.zoom_level * 100)
     end },
     { "<Shift-Scroll>", "Scroll the current page left/right.", function (w, o)
         w:scroll{ xrel = settings.get_setting("window.scroll_step")*o.dy }
@@ -133,17 +134,29 @@ local actions = { scroll = {
 }, zoom = {
     zoom_in = {
         desc = "Zoom in to the current page.",
-        func = function (w, m) w:zoom_in(settings.get_setting("window.zoom_step") * (m.count or 1)) end,
+        func = function (w, m)
+            w:zoom_in(settings.get_setting("window.zoom_step") * (m.count or 1))
+            settings.override_setting_for_view(w.view, "webview.zoom_level", w.view.zoom_level * 100)
+        end,
     },
     zoom_out = {
         desc = "Zoom out from the current page.",
-        func = function (w, m) w:zoom_out(settings.get_setting("window.zoom_step") * (m.count or 1)) end,
+        func = function (w, m)
+            w:zoom_out(settings.get_setting("window.zoom_step") * (m.count or 1))
+            settings.override_setting_for_view(w.view, "webview.zoom_level", w.view.zoom_level * 100)
+        end,
     },
     zoom_set = {
         desc = "Zoom to a specific percentage when specifying a count, and reset the page zoom otherwise.",
         func = function (w, m)
-            local zoom_level = m.count or settings.get_setting_for_view(w.view, "webview.zoom_level")
-            w:zoom_set(zoom_level/100)
+            if m.count then
+                w:zoom_set(m.count / 100)
+                settings.override_setting_for_view(w.view, "webview.zoom_level", m.count)
+            else
+                settings.override_setting_for_view(w.view, "webview.zoom_level", nil)
+                local zoom_level = settings.get_setting_for_view(w.view, "webview.zoom_level")
+                w:zoom_set(zoom_level / 100)
+            end
         end,
     },
 }}

--- a/lib/image_css.lua
+++ b/lib/image_css.lua
@@ -54,20 +54,36 @@ _M.stylesheet = stylesheet{ source = css }
 webview.add_signal("init", function (view)
     local top_level = {}
     local uri_mime_cache = {}
+    local image_loading = false
+    local was_image = false
 
     view:add_signal("load-status", function (v, status)
         if status == "provisional" then
             top_level[v] = true
-            settings.override_setting_for_view(view, "webview.zoom_level", nil)
+            image_loading = false
+            if was_image then
+                settings.override_setting_for_view(view, "webview.zoom_level", nil)
+            end
+            was_image = false
         elseif status == "committed" then
             top_level[v] = nil
             local mime = uri_mime_cache[v.uri]
             local is_image = mime and mime:match("^image/")
             view.stylesheets[_M.stylesheet] = is_image
             if is_image then
+                was_image = true
+                image_loading = true
                 wm:emit_signal(view, "image")
                 view.zoom_level = 1.0
                 settings.override_setting_for_view(view, "webview.zoom_level", 100)
+            end
+        elseif status == "finished" then
+            if image_loading then
+                image_loading = false
+                local w = window.ancestor(v)
+                if w and w.view == v then
+                    wm:emit_signal(view, "recalc")
+                end
             end
         end
     end)
@@ -79,6 +95,7 @@ webview.add_signal("init", function (view)
     end)
 
     local recalc_cb = function (v)
+        if image_loading then return end
         local w = window.ancestor(v)
         if w and w.view == v then
             wm:emit_signal(view, "recalc")

--- a/lib/webview.lua
+++ b/lib/webview.lua
@@ -744,7 +744,7 @@ _M.add_signal("init", function (view)
     view:add_signal("web-extension-loaded", function (v)
         -- Explicitly set the zoom, due to a WebKit bug that resets the
         -- apparent zoom level to 100% after a crash
-        set(v, "webview.zoom_level", settings.get_setting("webview.zoom_level"))
+        set(v, "webview.zoom_level", settings.get_setting_for_view(v, "webview.zoom_level"))
     end)
 end)
 


### PR DESCRIPTION
Zoom changes were lost on reload and navigation steps because image_css cleared the per-view setting override on every load and no binding stored the user's zoom. After a web-extension crash, zoom also reverted to the global default rather than the per-view value.

- binds.lua: <Control-Scroll>, zoom_in and zoom_out now write the new level back as a per-view override; zoom_set with a count stores the override, and without a count clears it and resets to the resolved default (domain-specific or global) instead of re-applying the current override.
- webview.lua: on web-extension reload, restore the per-view zoom override via get_setting_for_view() instead of get_setting().
- image_css.lua: only clear the zoom override when leaving an image page (was_image guard), so user zoom on regular pages survives navigation. Also suppress intermediate recalc signals during image load and emit one on "finished", so the vertical-overflow class is computed against settled body/image dimensions.