### PR TITLE
Set user agent before dispatching webview navigation requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,7 @@
 - Fixed a crash when serializing NULL lightuserdata values, which could occur with garbage-collected Lua objects used as weak table keys (fixes #1117).
 - Fixed a buffer overflow in IPC socket handling when socket paths exceed the `AF_UNIX` `sun_path` limit; replaced unsafe `strcpy` with a length-checked copy.
 - Fixed `dom_element.c` to be C99/clang compliant.
-- Fixed `webview.user_agent` not being applied to the first HTTP request after a webview is created; the setting is now resolved on the `navigation-request` signal so it is in effect before WebKit dispatches the request, including for reloads (fixes #886).
-- Restored the `enable_hyperlink_auditing` setting for builds against WebKitGTK versions prior to 2.50. On newer versions, the setting is not exposed, as it's deprecated and a no-op.
+- Fixed all webview settings (including `webview.user_agent`, `webview.enable_javascript`, domain-specific settings) not being applied before the first HTTP request on a newly created webview. All settings are now applied eagerly at webview creation and updated at `navigation-request` time — before WebKit dispatches the request — using the target URI for domain lookup (fixes #886).
 
 ### Contributors to this release:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed a crash when serializing NULL lightuserdata values, which could occur with garbage-collected Lua objects used as weak table keys (fixes #1117).
 - Fixed a buffer overflow in IPC socket handling when socket paths exceed the `AF_UNIX` `sun_path` limit; replaced unsafe `strcpy` with a length-checked copy.
 - Fixed `dom_element.c` to be C99/clang compliant.
+- Fixed `webview.user_agent` not being applied to the first HTTP request after a webview is created; the setting is now resolved on the `navigation-request` signal so it is in effect before WebKit dispatches the request, including for reloads (fixes #886).
 
 ### Contributors to this release:
 

--- a/lib/settings.lua
+++ b/lib/settings.lua
@@ -265,6 +265,19 @@ end
 
 local uri_domain_cache = {}
 
+local function lookup_setting_by_uri(uri, key)
+    if uri ~= uri_domain_cache.uri then
+        uri_domain_cache.uri = uri
+        uri_domain_cache.domains = (uri and uri ~= "")
+            and lousy.uri.domains_from_uri(uri) or {}
+    end
+    for _, domain in ipairs(uri_domain_cache.domains) do
+        local value = (S.domain[domain] or {})[key]
+        if value ~= nil then return value, domain end
+    end
+    return S.domain[""][key]
+end
+
 --- Retrieve the value of a setting for a webview.
 --
 -- This function considers, in order:
@@ -281,20 +294,27 @@ local uri_domain_cache = {}
 _M.get_setting_for_view = function (view, key)
     assert(type(view) == "widget" and view.type == "webview")
     -- view-specific overrides
-    local tree, uri = S.view_overrides[view], view.uri
+    local tree = S.view_overrides[view]
     if tree and tree[key] then return tree[key] end
-    -- domain-specific values
-    if uri ~= uri_domain_cache.uri then
-        uri_domain_cache.uri = uri
-        uri_domain_cache.domains = lousy.uri.domains_from_uri(uri)
-    end
-    local domains = uri_domain_cache.domains
-    for _, domain in ipairs(domains) do
-        local value = (S.domain[domain] or {})[key]
-        if value ~= nil then return value, domain end
-    end
-    -- non-domain-specific / default value
-    return S.domain[""][key]
+    return lookup_setting_by_uri(view.uri, key)
+end
+
+--- Retrieve the value of a setting for a target URI.
+--
+-- Useful before a navigation has completed, when `view.uri` is still the
+-- previous URI but the setting must reflect the *target* URI's domain.
+-- This function considers, in order:
+--
+-- 1. the setting's domain-specific values for `uri`
+-- 2. the setting's non-domain-specific value
+-- 3. the setting's default value
+--
+-- The settings key must be a valid settings key.
+-- @tparam string uri The target URI.
+-- @tparam string key The key of the setting to retrieve.
+-- @return The value of the setting.
+_M.get_setting_for_uri = function (uri, key)
+    return lookup_setting_by_uri(uri, key)
 end
 
 --- Add or remove a view-specific override for a setting.

--- a/lib/settings.lua
+++ b/lib/settings.lua
@@ -263,7 +263,7 @@ local function S_overwrite_table(domain, k, v)
     for kk, vv in pairs(v) do tbl[kk] = vv end
 end
 
-local uri_domain_cache = {}
+local uri_domain_cache = { domains = {} }
 
 local function lookup_setting_by_uri(uri, key)
     if uri ~= uri_domain_cache.uri then
@@ -314,6 +314,30 @@ end
 -- @tparam string key The key of the setting to retrieve.
 -- @return The value of the setting.
 _M.get_setting_for_uri = function (uri, key)
+    return lookup_setting_by_uri(uri, key)
+end
+
+--- Retrieve the value of a setting for a webview navigating to a given URI.
+--
+-- Like `get_setting_for_view`, but uses `uri` for domain lookup instead of
+-- `view.uri`. Useful at `navigation-request` time, when `view.uri` is still
+-- the previous URI but the target domain's settings should already apply.
+-- This function considers, in order:
+--
+-- 1. any view-specific overrides
+-- 2. the setting's domain-specific values for `uri`
+-- 3. the setting's non-domain-specific value
+-- 4. the setting's default value
+--
+-- The settings key must be a valid settings key.
+-- @tparam widget view The webview.
+-- @tparam string uri The target URI.
+-- @tparam string key The key of the setting to retrieve.
+-- @return The value of the setting.
+_M.get_setting_for_view_at_uri = function (view, uri, key)
+    assert(type(view) == "widget" and view.type == "webview")
+    local tree = S.view_overrides[view]
+    if tree and tree[key] then return tree[key] end
     return lookup_setting_by_uri(uri, key)
 end
 

--- a/lib/webview.lua
+++ b/lib/webview.lua
@@ -744,28 +744,30 @@ _M.add_signal("init", function (view)
             wv[k] = v
         end
     end
-    local set_all = function (vv)
+    -- Apply all webview settings for the given URI's domain, respecting any
+    -- view-specific overrides. Used at navigation-request time when view.uri
+    -- is still the previous URI.
+    local set_all_for_uri = function (vv, uri)
         for k in pairs(webview_settings) do
-            local v, match = settings.get_setting_for_view(vv, k)
+            local v, match = settings.get_setting_for_view_at_uri(vv, uri, k)
             set(vv, k, v, match)
         end
+        local val, match = settings.get_setting_for_view_at_uri(vv, uri, "webview.user_agent")
+        set(vv, "webview.user_agent", val, match)
     end
-    -- user_agent must be assigned before WebKit dispatches the request:
-    -- load-status fires after the network request has started.
-    local apply_user_agent = function (v, uri)
-        local val, match = settings.get_setting_for_uri(uri or "", "webview.user_agent")
-        set(v, "webview.user_agent", val, match)
-    end
-    apply_user_agent(view, view.uri)
+    -- Apply all settings eagerly so WebKit defaults are overridden before the
+    -- first navigation.
+    set_all_for_uri(view, view.uri)
+    -- Re-apply all settings for the target URI before WebKit dispatches the
+    -- request. This is the earliest point at which the target domain is known.
     view:add_signal("navigation-request", function (v, uri)
-        apply_user_agent(v, uri)
+        set_all_for_uri(v, uri)
     end)
     view:add_signal("load-status", function (v, status)
-        if v.uri == "about:blank" then
-            return
-        elseif status == "redirected" then
-            apply_user_agent(v, v.uri)
-        elseif status == "committed" then set_all(v) end
+        if v.uri == "about:blank" then return end
+        if status == "redirected" or status == "committed" then
+            set_all_for_uri(v, v.uri)
+        end
     end)
     view:add_signal("web-extension-loaded", function (v)
         -- Explicitly set the zoom, due to a WebKit bug that resets the

--- a/lib/webview.lua
+++ b/lib/webview.lua
@@ -732,13 +732,21 @@ _M.add_signal("init", function (view)
             set(vv, k, v, match)
         end
     end
-    -- Set domain-specific values on page load
+    -- user_agent must be assigned before WebKit dispatches the request:
+    -- load-status fires after the network request has started.
+    local apply_user_agent = function (v, uri)
+        local val, match = settings.get_setting_for_uri(uri or "", "webview.user_agent")
+        set(v, "webview.user_agent", val, match)
+    end
+    apply_user_agent(view, view.uri)
+    view:add_signal("navigation-request", function (v, uri)
+        apply_user_agent(v, uri)
+    end)
     view:add_signal("load-status", function (v, status)
         if v.uri == "about:blank" then
             return
-        elseif status == "provisional" or status == "redirected" then
-            local val, match = settings.get_setting_for_view(v, "webview.user_agent")
-            set(v, "webview.user_agent", val, match)
+        elseif status == "redirected" then
+            apply_user_agent(v, v.uri)
         elseif status == "committed" then set_all(v) end
     end)
     view:add_signal("web-extension-loaded", function (v)

--- a/tests/async/test_webview_settings.lua
+++ b/tests/async/test_webview_settings.lua
@@ -60,6 +60,29 @@ T.test_enable_javascript_applied_on_first_navigation = function ()
     assert.is_false(captured_js)
 end
 
+T.test_domain_setting_overrides_global_on_first_navigation = function ()
+    test.wait_for_idle()
+
+    -- For luakit-test://hello_world.html, soup.parse_uri().host == "hello_world.html",
+    -- so that is the domain key used for per-domain lookups.
+    local dom = settings.on["hello_world.html"]
+    settings.webview.user_agent = "GlobalAgent/1.0"
+    dom.webview.user_agent = "DomainAgent/2.0"
+
+    local view = webview.new({})
+    local captured_ua
+    view:add_signal("navigation-request", function (v)
+        captured_ua = v.user_agent
+    end)
+
+    view.uri = test.http_server() .. "hello_world.html"
+    test.wait_for_view(view)
+
+    settings.webview.user_agent = ""
+    dom.webview.user_agent = ""
+    assert.equal("DomainAgent/2.0", captured_ua)
+end
+
 return T
 
 -- vim: et:sw=4:ts=8:sts=4:tw=80

--- a/tests/async/test_webview_settings.lua
+++ b/tests/async/test_webview_settings.lua
@@ -1,0 +1,65 @@
+--- Test that webview settings are applied before the first HTTP request.
+--
+-- Verifies that settings.get_setting_for_view_at_uri is called via the
+-- navigation-request signal handler before WebKit dispatches any network
+-- request, so the correct WebKitSettings are in place from the very first
+-- connection.
+--
+-- @copyright 2026 c0dev0id
+
+local test = require "tests.lib"
+local assert = require "luassert"
+
+uris = { "about:blank" }
+require "config.rc"
+
+local settings = require "settings"
+local webview = require "webview"
+
+local T = {}
+
+T.test_user_agent_applied_on_first_navigation = function ()
+    test.wait_for_idle()
+
+    local orig = settings.webview.user_agent
+    settings.webview.user_agent = "TestAgent/1.0"
+
+    local view = webview.new({})
+
+    -- This handler runs after webview.lua's navigation-request handler (FIFO
+    -- ordering), so set_all_for_uri has already applied the new user_agent.
+    local captured_ua
+    view:add_signal("navigation-request", function (v)
+        captured_ua = v.user_agent
+    end)
+
+    view.uri = test.http_server() .. "hello_world.html"
+    test.wait_for_view(view)
+
+    settings.webview.user_agent = orig
+    assert.equal("TestAgent/1.0", captured_ua)
+end
+
+T.test_enable_javascript_applied_on_first_navigation = function ()
+    test.wait_for_idle()
+
+    local orig = settings.webview.enable_javascript
+    settings.webview.enable_javascript = false
+
+    local view = webview.new({})
+
+    local captured_js
+    view:add_signal("navigation-request", function (v)
+        captured_js = v.enable_javascript
+    end)
+
+    view.uri = test.http_server() .. "hello_world.html"
+    test.wait_for_view(view)
+
+    settings.webview.enable_javascript = orig
+    assert.is_false(captured_js)
+end
+
+return T
+
+-- vim: et:sw=4:ts=8:sts=4:tw=80


### PR DESCRIPTION
This should fix the issue where a custom user agent is not set before a navigation, redirect or reload is performed.

settings.webview.user_agent was previously assigned on the load-status:provisional handler, which fires after WebKit has already initiated the network request. The first HTTP request from a fresh webview therefore went out with WebKit's default UA. Subsequent navigations worked only because the setting had been applied by the prior load.

The fix is to resolve the user_agent on the navigation-request signal (emitted from decide_policy_cb before the request is dispatched) using the target URI for per-domain lookup. The setting is also applied once at init time to cover any pre-navigation reads. A new settings.get_setting_for_uri helper performs the domain lookup against a URI string instead of a view, since view.uri is still the previous URI at navigation-request time.

Should fix #886 