### PR TITLE
Block tracking pings via lib/hyperlink_auditing_wm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,13 @@
 - Fixed a buffer overflow in IPC socket handling when socket paths exceed the `AF_UNIX` `sun_path` limit; replaced unsafe `strcpy` with a length-checked copy.
 - Fixed `dom_element.c` to be C99/clang compliant.
 - Restored the `enable_hyperlink_auditing` setting for builds against WebKitGTK versions prior to 2.50. On newer versions, the setting is not exposed, as it's deprecated and a no-op.
+- Added hyperlink_auditing_wm to block tracking pings on WebKit 2.50+
 
 ### Contributors to this release:
 
 - @balejk
 - @c0dev0id
+- @fictitiousexistence
 
 ## [2.4.0]
 
@@ -51,7 +53,7 @@
 
 ### Fixed
 
-- Fixed build in a git worktree checkout 
+- Fixed build in a git worktree checkout
 - Fixed undoclose test sequence issue
 - Fixed luaH_init() implicit prototype warning
 - Fixed refresh being needed for the correct NoScript policy to take effect.

--- a/config/rc.lua
+++ b/config/rc.lua
@@ -170,6 +170,14 @@ local go_input = require "go_input"
 local go_next_prev = require "go_next_prev"
 local go_up = require "go_up"
 
+-- Block hyperlink auditing / tracking pings
+do
+    local maj, min = luakit.webkit_version:match("^(%d+)%.(%d+)")
+    if tonumber(maj) * 1000 + tonumber(min) > 2050 then
+        require_web_module("hyperlink_auditing_wm")
+    end
+end
+
 -- Filter Referer HTTP header if page domain does not match Referer domain
 require_web_module("referer_control_wm")
 

--- a/lib/domain_props.lua
+++ b/lib/domain_props.lua
@@ -104,6 +104,7 @@ local _M = {}
 
 msg.warn("domain_props.lua is deprecated, and will be removed in the next release!")
 msg.warn("all functionality (and more!) has been moved to settings.lua")
+msg.warn("enable_hyperlink_auditing no longer works per domain in WebKit 2.50+, only on or off globally")
 
 return _M
 

--- a/lib/hyperlink_auditing_wm.lua
+++ b/lib/hyperlink_auditing_wm.lua
@@ -1,0 +1,22 @@
+-- Block tracking pings used in the ping attribute of html <a>
+-- Displays message in Web Inspector when a ping is blocked.
+-- require_web_module("hyperlink_auditing")
+-- @module hyperlink_auditing
+
+
+local _M = {}
+
+luakit.add_signal("page-created", function(page)
+        page:add_signal("send-request", function(p, _, headers)
+            header = headers["Content-Type"]
+            if header and header == "text/ping" then
+                local msg = "Blocked Tracking Ping "
+                if headers["Ping-To"] then
+                    msg = msg .. "to: " .. headers["Ping-To"]
+                end
+                return msg
+            end
+        end)
+end)
+
+return _M


### PR DESCRIPTION
As of WebKitGTK 2.50, the hyperlink-auditing setting in deprecated and has been removed. Pings are now sent by default.

This PR adds lib/hyperlink_auditing_wm to block all pings for Webkit 2.50+.