### PR TITLE
Fix IPC endpoints desyncing from WebView widgets, and associated Undefined Behaviour (coredumps)

### DIFF
--- a/common/ipc.c
+++ b/common/ipc.c
@@ -274,6 +274,7 @@ ipc_endpoint_decref(ipc_endpoint_t *ipc)
     }
     ipc->status = IPC_ENDPOINT_FREED;
     g_slice_free(ipc_endpoint_t, ipc);
+    debug("Freeing IPC endpoint 0x%lx", (unsigned long)ipc);
 }
 
 void
@@ -315,15 +316,16 @@ ipc_endpoint_replace(ipc_endpoint_t *orig, ipc_endpoint_t *new)
     g_assert(orig->status == IPC_ENDPOINT_DISCONNECTED);
     g_assert(new->status == IPC_ENDPOINT_CONNECTED);
 
-    /* Incref always succeeds because this is called from a message
-     * handler, which holds a temporary ref to the ipc channel  */
-    ipc_endpoint_incref_no_check(new);
-
     /* Send all queued messages */
     if (orig->queue) {
         while (!g_queue_is_empty(orig->queue)) {
             queued_ipc_t *msg = g_queue_pop_head(orig->queue);
             msg->ipc = new;
+            /* When this message was originally added to orig's
+             * queue, the refcount was incremented, so transfer
+             * that reference to new.
+             */
+            ipc_endpoint_decref(orig);
             ipc_endpoint_incref_no_check(new);
             g_async_queue_push(send_queue, msg);
         }
@@ -332,7 +334,14 @@ ipc_endpoint_replace(ipc_endpoint_t *orig, ipc_endpoint_t *new)
         orig->queue = NULL;
     }
 
+    /* Presumably this will result in orig being freed: */
     ipc_endpoint_decref(orig);
+    /* Meanwhile, new's refcount will come back down to
+     * 1 as the send thread fires off all the messages
+     * we added to the queue. If the owner needs more
+     * references, it can increment the refcount after
+     * this function returns. A priori, 1 is enough.
+     */
     return new;
 }
 

--- a/common/ipc.c
+++ b/common/ipc.c
@@ -84,11 +84,11 @@ ipc_send_thread(gpointer UNUSED(user_data))
 
         if((ipc->channel != NULL) && (ipc->status == IPC_ENDPOINT_CONNECTED))
             g_io_channel_write_chars(ipc->channel, (gchar*)data, header->length, NULL, NULL);
-
-        if((ipc->channel != NULL) && (ipc->status == IPC_ENDPOINT_CONNECTED))
-            ipc_endpoint_decref(ipc);
         else
             error("Trying to send an ipc message, but the endpoint went away.");
+
+        /* Remove keep-alive reference */
+        ipc_endpoint_decref(ipc);
 
         g_free(out);
     }
@@ -153,12 +153,8 @@ ipc_recv_and_dispatch_or_enqueue(ipc_endpoint_t *ipc)
              *
              * If we do not close the socket, glib will continue to
              * call the G_IO_IN handler.
-             *
-             * We decrement the refcount to 1 here, and when ipc_recv
-             * decrements the refcount to zero, the socket will be
-             * disconnected.
              */
-            g_atomic_int_dec_and_test(&ipc->refcount);
+            ipc_endpoint_disconnect(ipc);
             return;
         case G_IO_STATUS_ERROR:
             if (!g_str_equal(ipc->name, "UI"))
@@ -201,9 +197,11 @@ ipc_recv_and_dispatch_or_enqueue(ipc_endpoint_t *ipc)
 static gboolean
 ipc_recv(GIOChannel *UNUSED(channel), GIOCondition UNUSED(cond), ipc_endpoint_t *ipc)
 {
+    /* Keep the endpoint alive while the message is being received */
     if (!ipc_endpoint_incref(ipc))
         return TRUE;
     ipc_recv_and_dispatch_or_enqueue(ipc);
+    /* Remove keep-alive reference */
     ipc_endpoint_decref(ipc);
     return TRUE;
 }
@@ -213,7 +211,7 @@ ipc_hup(GIOChannel *UNUSED(channel), GIOCondition UNUSED(cond), ipc_endpoint_t *
 {
     g_assert(ipc->status == IPC_ENDPOINT_CONNECTED);
     g_assert(ipc->channel);
-    ipc_endpoint_decref(ipc);
+    ipc_endpoint_disconnect(ipc);
     return TRUE;
 }
 

--- a/ipc.c
+++ b/ipc.c
@@ -44,6 +44,8 @@ static char *socket_path;
 GMutex socket_path_lock;
 GCond socket_path_cond;
 
+static GHashTable *pending_page_created_msgs = NULL;
+
 IPC_NO_HANDLER(lua_require_module)
 IPC_NO_HANDLER(web_extension_loaded)
 IPC_NO_HANDLER(crash)
@@ -65,15 +67,15 @@ ipc_recv_lua_ipc(ipc_endpoint_t *UNUSED(ipc), const ipc_lua_ipc_t *msg, guint le
 }
 
 void
-ipc_recv_scroll(ipc_endpoint_t *UNUSED(ipc), ipc_scroll_t *msg, guint UNUSED(length))
-{
-    g_ptr_array_foreach(globalconf.webviews, (GFunc)webview_scroll_recv, msg);
-}
-
-void
 ipc_recv_eval_js(ipc_endpoint_t *UNUSED(ipc), const guint8 *msg, guint length)
 {
     run_javascript_finished(msg, length);
+}
+
+void
+free_page_created_msg(gpointer data)
+{
+    g_slice_free(ipc_page_created_t, data);
 }
 
 void
@@ -81,11 +83,38 @@ ipc_recv_page_created(ipc_endpoint_t *ipc, const ipc_page_created_t *msg, guint 
 {
     widget_t *w = webview_get_by_id(msg->page_id);
 
-    /* Page may already have been closed */
-    if (!w) return;
+    if (w) {
+        webview_connect_to_endpoint(w, ipc);
+        webview_set_web_process_id(w, msg->pid);
+    } else {
+        /* If we can't find this page, it's possible that the WebView's page-id
+         * hasn't been updated yet, so we should re-fire this function once that
+         * happens. We can do that once this endpoint receives a scroll message
+         * (which it should once the page is actually rendered).
+         * I think the easiest way of doing this is maintaining a hashmap of
+         * pending page creation messages. The key is simply the IPC endpoint
+         * pointer, using "direct" hashing and equality checks (hence NULL args
+         * to the hashmap constructor), with a corresponding inc/dec of the
+         * refcount when it is added / removed in the hashmap. The value is a
+         * copy of the message itself, which we create with g_slice_dup and free
+         * with g_slice_free.
+         */
+        pending_page_created_msgs = pending_page_created_msgs ?: g_hash_table_new_full(NULL,NULL,(GDestroyNotify)ipc_endpoint_decref,free_page_created_msg);
+        if (!ipc_endpoint_incref(ipc))
+            return;
+        g_hash_table_insert(pending_page_created_msgs, ipc, g_slice_dup(ipc_page_created_t, msg));
+    }
+}
 
-    webview_connect_to_endpoint(w, ipc);
-    webview_set_web_process_id(w, msg->pid);
+void
+ipc_recv_scroll(ipc_endpoint_t *ipc, ipc_scroll_t *msg, guint UNUSED(length))
+{
+    if (pending_page_created_msgs && g_hash_table_contains(pending_page_created_msgs, ipc)) {
+        ipc_page_created_t *pmsg = g_hash_table_lookup(pending_page_created_msgs, ipc);
+        ipc_recv_page_created(ipc, pmsg, sizeof(ipc_page_created_t));
+        g_hash_table_remove(pending_page_created_msgs, ipc);
+    }
+    g_ptr_array_foreach(globalconf.webviews, (GFunc)webview_scroll_recv, msg);
 }
 
 static gchar *

--- a/widgets/webview.c
+++ b/widgets/webview.c
@@ -1327,8 +1327,16 @@ webview_connect_to_endpoint(widget_t *w, ipc_endpoint_t *ipc)
     g_assert(w->info->tok == L_TK_WEBVIEW);
     g_assert(ipc);
 
-    /* Replace old endpoint with new, sendinq queued data */
+    /* Replace old endpoint with new, sending queued data */
     webview_data_t *d = w->data;
+    if(d->ipc == ipc)
+        return;
+    if(d->ipc->channel)
+        /* Old one has no business being connected at this point;
+         * it probably just hasn't realized that the channel is
+         * broken yet!
+         */
+        ipc_endpoint_disconnect(d->ipc);
     d->ipc = ipc_endpoint_replace(d->ipc, ipc);
 
     lua_State *L = common.L;

--- a/widgets/webview.c
+++ b/widgets/webview.c
@@ -1312,10 +1312,6 @@ luakit_uri_scheme_request_cb(WebKitURISchemeRequest *request, const gchar *schem
 gboolean
 webview_crashed_cb(WebKitWebView *UNUSED(view), widget_t *w)
 {
-    /* Give webview a new disconnected IPC endpoint */
-    webview_data_t *d = w->data;
-    d->ipc = ipc_endpoint_new("UI");
-
     /* Emit 'crashed' signal on web view */
     lua_State *L = common.L;
     luaH_object_push(L, w->ref);


### PR DESCRIPTION
I did a bit of an audit on how refcounting is managed for IPC endpoints, and explained what I found starting here: https://github.com/luakit/luakit/issues/1067#issuecomment-4882449713

While this doesn't solve the underlying data race (https://github.com/luakit/luakit/commit/525c03d19d99aabcc80d40f09b1a78b234093449#diff-23e66972634a71b55ae442fbb3cb8ce1bda6e4f0aa885e471affbf4e28b071c6R34 may do that), this does eliminate a whole suite of use-after-free errors (which could also occur when simply closing the browser) and possibly also some memory leaks.

This should finally put an end to #1067, though again the data race needs to be fixed to prevent some of the co-occurring annoyances.